### PR TITLE
Bump `lager` to 2.2.3 for Erlang 19 support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
 
 {deps, [
         {lager, ".*",
-            {git, "git://github.com/basho/lager.git", {tag, "2.2.0"}}},
+            {git, "git://github.com/basho/lager.git", {tag, "2.2.3"}}},
         {vmq_commons, ".*", {git, "git://github.com/erlio/vmq_commons.git", "7b6171b"}}
         ]}.
 


### PR DESCRIPTION
Compiling `vmq_mzbench` on Erlang 19 explodes in a very unpleasant way. Bumping to lager version `2.2.3` fixes it for me.

https://github.com/erlang-lager/lager/pull/361

https://github.com/basho/lager/commit/1c42c3bffbab49b0f06c9a916b00ca4911ae6a2f

Example of the explosion:

```
==> vmq_commons (compile)
/tmp/bench_mzbench_api_palectro-dev-mzbench-i0b4b032be8ad55dc0_1488_315630_504936/deployment_code/deps/vmq_commons/src/on_unsubscribe_hook.erl:none: error in parse transform 'lager_transform': {function_clause,
                                             [{lager_transform,
                                               '-walk_ast/2-fun-0-',
                                               [{typed_record_field,
                                                 {record_field,34,
                                                  {atom,34,proto_ver}},
                                                 {user_type,34,proto_version,
                                                  []}}],
                                               [{file,

```