### PR TITLE
missing counter val for: mqtt.connection.reconnects

### DIFF
--- a/src/mqtt_worker.erl
+++ b/src/mqtt_worker.erl
@@ -220,7 +220,7 @@ stats({connect_out, ClientId}, State) -> % log connection attempt
 stats({connack_in, ClientId}, State) ->
     diff(ClientId, State, "mqtt.connection.connack.latency", histogram);
 stats({reconnect, _ClientId}, State) ->
-    mzb_metrics:notify({"mqtt.connection.reconnects", counter}),
+    mzb_metrics:notify({"mqtt.connection.reconnects", counter}, 1),
     State;
 stats({publish_out, MsgId, QoS}, State)  ->
     case QoS of


### PR DESCRIPTION
Ran into this error:

`gen_fsm <0.11821.0> in state connected terminated with reason: call to undefined function mzb_metrics:notify/1 from mqtt_worker:stats/2 line 223`

and realized that the call was missing the counter value -
mzb_metrics:notify/2 needs the actual counter value to update.