### PR TITLE
Add new statements and extend functionality

### DIFF
--- a/scenarios/query.bdl
+++ b/scenarios/query.bdl
@@ -1,0 +1,63 @@
+#!benchDL
+
+#######
+# Query Scenario:
+# This scenario simulates client server communication pattern.
+# 1k servers subscribes for private topic and replies for incoming
+# requests.
+# 1 client sends request to one random server each time with 500 rps
+# frequency.
+# Request is sent with QOS2, response is delivered with QOS1.
+# Each MQTT client binds to random IP from local network
+# interface of choice.
+# Overall Msg rate: 1k msg/s
+# Message Size: 150 random bytes
+# Runtime: 5 min
+#######
+
+make_install(git = "https://github.com/erlio/vmq_mzbench.git", branch = "master")
+
+pool(size = 1, worker_type = mqtt_worker):
+    connect(
+        host = "127.0.0.1",
+        port = 1883,
+        transport = t(gen_tcp, [t(ip, random_client_ip("eth"))]),
+        client = fixed_client_id("server", worker_id()),
+        clean_session = true,
+        keepalive_interval = 60,
+        proto_version = 4,
+        reconnect_timeout = 30
+    )
+    wait(4 sec)
+    subscribe("prefix/clients/#", 1)
+    loop(time = 5 min, rate = 500 rps, poisson = true):
+        publish_to_one(
+            "prefix/servers/",
+            fixed_client_id("client", random_number(1, 1000)),
+            random_binary(150),
+            2
+        )
+    wait(4 sec)
+    set_signal(done, 1)
+    wait(10 sec)
+    disconnect()
+
+pool(size = 1000, worker_type = mqtt_worker, worker_start = poisson(1000 rps)):
+    connect(
+        host = "127.0.0.1",
+        port = 1883,
+        transport = t(gen_tcp, [t(ip, random_client_ip("eth"))]),
+        client = fixed_client_id("client", worker_id()),
+        clean_session = true,
+        keepalive_interval = 60,
+        proto_version = 4,
+        reconnect_timeout = 30
+    )
+    wait(4 sec)
+    subscribe_to_self("prefix/servers/", 2)
+    forward("prefix/clients/", 1)
+    wait(5 min)
+    wait_signal(done, 1)
+    wait(10 sec)
+    idle()
+    disconnect()

--- a/src/mqtt_worker.erl
+++ b/src/mqtt_worker.erl
@@ -9,6 +9,7 @@
     disconnect/2,
     publish/5,
     publish/6,
+    subscribe/3,
     subscribe/4,
     unsubscribe/3,
     random_client_id/3,
@@ -18,6 +19,7 @@
     idle/2,
     forward/4,
     publish_to_one/6,
+    publish_to_one/7,
     client/2,
     worker_id/2,
     fixed_client_id/4,
@@ -64,53 +66,64 @@ metrics() ->
         {group, "MQTT Pub to Sub Latency", [
             {graph, #{title => "Pub to Sub Latency (QoS 0)", metrics => [{"mqtt.message.pub_to_sub.latency", histogram}]}},
             {graph, #{title => "Pub to Sub Latency (QoS 1)", metrics => [{"mqtt.message.pub_to_sub.latency.qos1", histogram}]}},
-            {graph, #{title => "Pub to Sub Latency (QoS 2)", metrics => [{"mqtt.message.pub_to_sub.latency.qos2", histogram}]}}]
-        },
+            {graph, #{title => "Pub to Sub Latency (QoS 2)", metrics => [{"mqtt.message.pub_to_sub.latency.qos2", histogram}]}}
+        ]},
         {group, "MQTT Publishers QoS 1", [
             % QoS 1 Publisher flow
             {graph, #{title => "QoS 1: Publish to Puback latency", metrics => [{"mqtt.publisher.qos1.puback.latency", histogram}]}},
             {graph, #{title => "QoS 1: Pubacks received total", metrics => [{"mqtt.publisher.qos1.puback.in.total", counter}]}},
-            {graph, #{title => "QoS 1: Outstanding Pubacks (Waiting Acks)",
-                metrics => [{"mqtt.publisher.qos1.puback.waiting", counter}]}}]},
+            {graph, #{title => "QoS 1: Outstanding Pubacks (Waiting Acks)", metrics => [{"mqtt.publisher.qos1.puback.waiting", counter}]}}
+        ]},
         {group, "MQTT Publishers QoS 2", [
             % QoS 2 Publisher flow
             {graph, #{title => "QoS 2: Publish to Pubrec_in latency", metrics => [{"mqtt.publisher.qos2.pub_out_to_pubrec_in.latency", histogram}]}},
             {graph, #{title => "QoS 2: Pubrecs received total", metrics => [{"mqtt.publisher.qos2.pubrec.in.total", counter}]}},
-            {graph, #{title => "QoS 2: Pubrec_in to Pubrel_out internal latency",
-                metrics => [{"mqtt.publisher.qos2.pubrec_in_to_pubrel_out.internal_latency", histogram}]}},
-            {graph, #{title => "QoS 2: Pubrel_out to Pubcomp_in latency", metrics => [{"mqtt.publisher.qos2.pubrel_out_to_pubcomp_in.latency",
-                histogram}]}}]},
-
+            {graph, #{
+                title => "QoS 2: Pubrec_in to Pubrel_out internal latency",
+                metrics => [{"mqtt.publisher.qos2.pubrec_in_to_pubrel_out.internal_latency", histogram}]
+            }},
+            {graph, #{
+                title => "QoS 2: Pubrel_out to Pubcomp_in latency",
+                metrics => [{"mqtt.publisher.qos2.pubrel_out_to_pubcomp_in.latency", histogram}]
+            }},
+            {graph, #{title => "QoS 2: Outstanding Pubrecs (Waiting Acks)", metrics => [{"mqtt.publisher.qos2.pubrec.waiting", counter}]}},
+            {graph, #{title => "QoS 2: Outstanding Pubcomps (Waiting Acks)", metrics => [{"mqtt.publisher.qos2.pubcomp.waiting", counter}]}}
+        ]},
         {group, "MQTT Connections", [
             {graph, #{title => "Connack Latency", metrics => [{"mqtt.connection.connack.latency", histogram}]}},
             {graph, #{title => "Total Connections", metrics => [{"mqtt.connection.current_total", counter}]}},
             {graph, #{title => "Connection errors", metrics => [{"mqtt.connection.connect.errors", histogram}]}},
-            {graph, #{title => "Reconnects", metrics => [{"mqtt.connection.reconnects", counter}]}}]},
-
+            {graph, #{title => "Reconnects", metrics => [{"mqtt.connection.reconnects", counter}]}}
+        ]},
         {group, "MQTT Messages", [
             {graph, #{title => "Total published messages", metrics => [{"mqtt.message.published.total", counter}]}},
-            {graph, #{title => "Total consumed messages", metrics => [{"mqtt.message.consumed.total", counter}]}}]},
-
+            {graph, #{title => "Total consumed messages", metrics => [{"mqtt.message.consumed.total", counter}]}}
+        ]},
         {group, "MQTT Consumers", [
             {graph, #{title => "Suback Latency", metrics => [{"mqtt.consumer.suback.latency", histogram}]}},
             {graph, #{title => "Unsuback Latency", metrics => [{"mqtt.consumer.unsuback.latency", histogram}]}},
             {graph, #{title => "Consumer Total", metrics => [{"mqtt.consumer.current_total", counter}]}},
             {graph, #{title => "Consumer Suback Errors", metrics => [{"mqtt.consumer.suback.errors", counter}]}},
-
-
             % QoS 1 consumer flow
-            {graph, #{title => "QoS 1: Publish_in to Puback_out internal latency",
-                metrics => [{"mqtt.consumer.qos1.publish_in_to_puback_out.internal_latency", histogram}]}},
-
+            {graph, #{
+                title => "QoS 1: Publish_in to Puback_out internal latency",
+                metrics => [{"mqtt.consumer.qos1.publish_in_to_puback_out.internal_latency", histogram}]
+            }},
             % QoS 2 consumer flow
-            {graph, #{title => "QoS 2: Publish_in to Pubrec_out internal latency",
-                metrics => [{"mqtt.consumer.qos2.publish_in_to_pubrec_out.internal_latency", histogram}]}},
-            {graph, #{title => "QoS 2: Pubrec_out to Pubrel_in latency",
-                metrics => [{"mqtt.consumer.qos2.pubrec_out_to_pubrel_in.latency", histogram}]}},
-            {graph, #{title => "QoS 2: Pubrel_in to Pubcomp_out internal latency", metrics =>
-            [{"mqtt.consumer.qos2.pubrel_in_to_pubcomp_out.internal_latency", histogram}]}}
-
-        ]}].
+            {graph, #{
+                title => "QoS 2: Publish_in to Pubrec_out internal latency",
+                metrics => [{"mqtt.consumer.qos2.publish_in_to_pubrec_out.internal_latency", histogram}]
+            }},
+            {graph, #{
+                title => "QoS 2: Pubrec_out to Pubrel_in latency",
+                metrics => [{"mqtt.consumer.qos2.pubrec_out_to_pubrel_in.latency", histogram}]
+            }},
+            {graph, #{
+                title => "QoS 2: Pubrel_in to Pubcomp_out internal latency",
+                metrics => [{"mqtt.consumer.qos2.pubrel_in_to_pubcomp_out.internal_latency", histogram}]
+            }}
+        ]}
+    ].
 
 %% ------------------------------------------------
 %% Gen_MQTT Callbacks (partly un-used)
@@ -206,15 +219,25 @@ publish(#state{mqtt_fsm = SessionPid} = State, _Meta, Topic, Payload, QoS, Retai
             {nil, State}
     end.
 
-subscribe(#state{mqtt_fsm = SessionPid} = State, _Meta, Topic, Qos) ->
-    case vmq_topic:validate_topic(subscribe, list_to_binary(Topic)) of
-        {ok, TTopic} ->
-            gen_emqtt:subscribe(SessionPid, TTopic, Qos),
-            {nil, State};
-        {error, Reason} ->
-            error_logger:warning_msg("Can't validate topic conf ~p due to ~p~n", [Topic, Reason]),
-            {nil, State}
-    end.
+
+subscribe(#state{mqtt_fsm = SessionPid} = State, _Meta, [T|_] = Topics) when is_tuple(T) ->
+    ValidTopics = lists:filtermap(
+        fun({Topic, Qos}) ->
+            case vmq_topic:validate_topic(subscribe, list_to_binary(Topic)) of
+                {ok, ValidTopic} ->
+                    {true, {ValidTopic, Qos}};
+                {error, Reason} ->
+                    error_logger:warning_msg("Can't validate topic conf ~p due to ~p~n", [Topic, Reason]),
+                    false
+            end
+        end,
+        Topics
+    ),
+    gen_emqtt:subscribe(SessionPid, ValidTopics),
+    {nil, State}.
+
+subscribe(State, Meta, Topic, Qos) ->
+    subscribe(State, Meta, [{Topic, Qos}]).
 
 unsubscribe(#state{mqtt_fsm = SessionPid} = State, _Meta, Topics) ->
     gen_emqtt:unsubscribe(SessionPid, Topics),
@@ -227,7 +250,10 @@ publish_to_self(#state{client = ClientId} = State, _Meta, TopicPrefix, Payload, 
     publish(State, _Meta, TopicPrefix ++ ClientId, Payload, Qos).
 
 publish_to_one(State, Meta, TopicPrefix, ClientId, Payload, Qos) ->
-    publish(State, Meta, TopicPrefix ++ ClientId, Payload, Qos).
+    publish_to_one(State, Meta, TopicPrefix, ClientId, Payload, Qos, false).
+
+publish_to_one(State, Meta, TopicPrefix, ClientId, Payload, Qos, Retain) ->
+    publish(State, Meta, TopicPrefix ++ ClientId, Payload, Qos, Retain).
 
 idle(#state{mqtt_fsm = SessionPid} = State, _Meta) ->
     gen_fsm:send_all_state_event(SessionPid, {idle}),
@@ -295,8 +321,8 @@ stats({reconnect, _ClientId}, State) ->
 stats({publish_out, MsgId, QoS}, State)  ->
     case QoS of
         0 -> ok;
-        1 -> mzb_metrics:notify({"mqtt.publisher.qos1.puback.waiting"}, 1);
-        2 -> mzb_metrics:notify({"mqtt.publisher.qos2.pubrec.waiting"}, 1)
+        1 -> mzb_metrics:notify({"mqtt.publisher.qos1.puback.waiting", counter}, 1);
+        2 -> mzb_metrics:notify({"mqtt.publisher.qos2.pubrec.waiting", counter}, 1)
     end,
     maps:put({outgoing, MsgId}, os:timestamp(), State);
 stats({publish_in, MsgId, Payload, QoS}, State) ->
@@ -334,6 +360,7 @@ stats({pubrec_in, MsgId}, State) ->
     T1 = maps:get({outgoing, MsgId}, State),
     mzb_metrics:notify({"mqtt.publisher.qos2.pub_out_to_pubrec_in.latency", histogram}, positive(timer:now_diff(T2, T1))),
     mzb_metrics:notify({"mqtt.publisher.qos2.pubrec.in.total"}, 1),
+    mzb_metrics:notify({"mqtt.publisher.qos2.pubrec.waiting", counter}, -1),
     NewState = maps:update({outgoing, MsgId}, T2, State),
     NewState;
 stats({pubrec_out, MsgId}, State) ->
@@ -346,6 +373,7 @@ stats({pubrel_out, MsgId}, State) ->
     T3 = os:timestamp(),
     T2 = maps:get({outgoing, MsgId}, State),
     mzb_metrics:notify({"mqtt.publisher.qos2.pubrec_in_to_pubrel_out.internal_latency", histogram}, positive(timer:now_diff(T3, T2))),
+    mzb_metrics:notify({"mqtt.publisher.qos2.pubcomp.waiting", counter}, 1),
     NewState = maps:update({outgoing, MsgId}, T3, State),
     NewState;
 stats({pubrel_in, MsgId}, State) ->
@@ -358,6 +386,7 @@ stats({pubcomp_in, MsgId}, State) ->
     T4 = os:timestamp(),
     T3 = maps:get({outgoing, MsgId}, State),
     mzb_metrics:notify({"mqtt.publisher.qos2.pubrel_out_to_pubcomp_in.latency", histogram}, positive(timer:now_diff(T4, T3))),
+    mzb_metrics:notify({"mqtt.publisher.qos2.pubcomp.waiting", counter}, -1),
     NewState = maps:remove({outgoing, MsgId}, State),
     NewState;
 stats({pubcomp_out, MsgId}, State) ->

--- a/src/mqtt_worker.erl
+++ b/src/mqtt_worker.erl
@@ -12,8 +12,12 @@
     subscribe/4,
     unsubscribe/3,
     random_client_id/3,
+    random_client_ip/3,
     subscribe_to_self/4,
     publish_to_self/5,
+    idle/2,
+    forward/4,
+    publish_to_one/6,
     client/2,
     worker_id/2,
     fixed_client_id/4,
@@ -43,6 +47,7 @@
 -include_lib("public_key/include/public_key.hrl").
 
 -record(state, {mqtt_fsm, client}).
+-record(mqtt, {action}).
 
 -behaviour(gen_emqtt).
 
@@ -135,15 +140,31 @@ on_unsubscribe(_Topics, State) ->
     mzb_metrics:notify({"mqtt.consumer.current_total", counter}, -1),
     {ok, State}.
 
-on_publish(_Topic, _Payload, State) ->
+on_publish(Topic, Payload, #mqtt{action=Action} = State) ->
     mzb_metrics:notify({"mqtt.message.consumed.total", counter}, 1),
-    {ok, State}.
+    case Action of
+        {forward, TopicPrefix, Qos} ->
+            {_Timestamp, OrigPayload} = binary_to_term(Payload),
+            ClientId = binary_to_list(lists:last(Topic)),
+            case vmq_topic:validate_topic(publish, list_to_binary(TopicPrefix ++ ClientId)) of
+                {ok, OutTopic} ->
+                    NewPayload = term_to_binary({os:timestamp(), OrigPayload}),
+                    gen_emqtt:publish(self(), OutTopic, NewPayload, Qos, false),
+                    mzb_metrics:notify({"mqtt.message.published.total", counter}, 1),
+                    {ok, State};
+                {error, Reason} ->
+                    error_logger:warning_msg("Can't validate topic ~p due to ~p~n", [Topic, Reason]),
+                    {ok, State}
+            end;
+        {idle} ->
+            {ok, State}
+    end.
 
 handle_call(_Req, _From, State) ->
     {reply, ok, State}.
 
-handle_cast(_Req, State) ->
-    {noreply, State}.
+handle_cast(Req, State) ->
+    {noreply, State#mqtt{action=Req}}.
 
 handle_info(_Req, State) ->
     {noreply, State}.
@@ -162,7 +183,8 @@ code_change(_OldVsn, State, _Extra) ->
 
 connect(State, _Meta, ConnectOpts) ->
     ClientId = proplists:get_value(client, ConnectOpts),
-    {ok, SessionPid} = gen_emqtt:start_link(?MODULE, [], [{info_fun, {fun stats/2, maps:new()}}|ConnectOpts]),
+    Args = #mqtt{action={idle}},
+    {ok, SessionPid} = gen_emqtt:start_link(?MODULE, Args, [{info_fun, {fun stats/2, maps:new()}}|ConnectOpts]),
     {nil, State#state{mqtt_fsm=SessionPid, client=ClientId}}.
 
 disconnect(#state{mqtt_fsm=SessionPid} = State, _Meta) ->
@@ -175,8 +197,8 @@ publish(State, _Meta, Topic, Payload, QoS) ->
 publish(#state{mqtt_fsm = SessionPid} = State, _Meta, Topic, Payload, QoS, Retain) ->
     case vmq_topic:validate_topic(publish, list_to_binary(Topic)) of
         {ok, TTopic} ->
-                    Payload1 = term_to_binary({os:timestamp(), Payload}),
-                    gen_emqtt:publish(SessionPid, TTopic, Payload1, QoS, Retain),
+            Payload1 = term_to_binary({os:timestamp(), Payload}),
+            gen_emqtt:publish(SessionPid, TTopic, Payload1, QoS, Retain),
             mzb_metrics:notify({"mqtt.message.published.total", counter}, 1),
             {nil, State};
         {error, Reason} ->
@@ -204,6 +226,17 @@ subscribe_to_self(#state{client = ClientId} = State, _Meta, TopicPrefix, Qos) ->
 publish_to_self(#state{client = ClientId} = State, _Meta, TopicPrefix, Payload, Qos) ->
     publish(State, _Meta, TopicPrefix ++ ClientId, Payload, Qos).
 
+publish_to_one(State, Meta, TopicPrefix, ClientId, Payload, Qos) ->
+    publish(State, Meta, TopicPrefix ++ ClientId, Payload, Qos).
+
+idle(#state{mqtt_fsm = SessionPid} = State, _Meta) ->
+    gen_fsm:send_all_state_event(SessionPid, {idle}),
+    {nil, State}.
+
+forward(#state{mqtt_fsm = SessionPid} = State, _Meta, TopicPrefix, Qos) ->
+    gen_fsm:send_all_state_event(SessionPid, {forward, TopicPrefix, Qos}),
+    {nil, State}.
+
 client(#state{client = Client}=State, _Meta) ->
     {Client, State}.
 
@@ -215,6 +248,17 @@ fixed_client_id(State, _Meta, Name, Id) -> {[Name, "-", integer_to_list(Id)], St
 
 random_client_id(State, _Meta, N) ->
     {randlist(N) ++ pid_to_list(self()), State}.
+
+random_client_ip(State, _Meta, IfPrefix) ->
+    {ok, Interfaces} = inet:getifaddrs(),
+    IfConfigurations = [Conf || {IfName, Conf} <- Interfaces, lists:prefix(IfPrefix, IfName)],
+    Addresses = [Ip || {addr, Ip} <- lists:flatten(IfConfigurations), tuple_size(Ip) == 4],
+    case length(Addresses) of
+        0 ->
+            {"0.0.0.0", State};
+        Total ->
+            {lists:nth(random:uniform(Total), Addresses), State}
+    end.
 
 load_client_cert(State, _Meta, CertBin) ->
     Pems = public_key:pem_decode(CertBin),
@@ -254,7 +298,7 @@ stats({publish_out, MsgId, QoS}, State)  ->
         1 -> mzb_metrics:notify({"mqtt.publisher.qos1.puback.waiting"}, 1);
         2 -> mzb_metrics:notify({"mqtt.publisher.qos2.pubrec.waiting"}, 1)
     end,
-    maps:put(MsgId, os:timestamp(), State);
+    maps:put({outgoing, MsgId}, os:timestamp(), State);
 stats({publish_in, MsgId, Payload, QoS}, State) ->
     T2 = os:timestamp(),
     {T1, _OldPayload} = binary_to_term(Payload),
@@ -264,17 +308,17 @@ stats({publish_in, MsgId, Payload, QoS}, State) ->
         1 -> mzb_metrics:notify({"mqtt.message.pub_to_sub.latency.qos1", histogram}, Diff);
         2 -> mzb_metrics:notify({"mqtt.message.pub_to_sub.latency.qos2", histogram}, Diff)
     end,
-    maps:put(MsgId, T2, State);
+    maps:put({incoming, MsgId}, T2, State);
 stats({puback_in, MsgId}, State) ->
-    T1 = maps:get(MsgId, State),
+    T1 = maps:get({outgoing, MsgId}, State),
     T2 = os:timestamp(),
     mzb_metrics:notify({"mqtt.publisher.qos1.puback.latency", histogram}, positive(timer:now_diff(T2, T1))),
     mzb_metrics:notify({"mqtt.publisher.qos1.puback.in.total", counter}, 1),
     mzb_metrics:notify({"mqtt.publisher.qos1.puback.waiting", counter}, -1),
-    NewState = maps:remove(MsgId, State),
+    NewState = maps:remove({outgoing, MsgId}, State),
     NewState;
 stats({puback_out, MsgId}, State) ->
-    diff(MsgId, State, "mqtt.consumer.qos1.publish_in_to_puback_out.internal_latency", histogram);
+    diff({incoming, MsgId}, State, "mqtt.consumer.qos1.publish_in_to_puback_out.internal_latency", histogram);
 stats({suback, MsgId}, State) ->
     diff(MsgId, State, "mqtt.consumer.suback.latency", histogram);
 stats({subscribe_out, MsgId}, State) ->
@@ -287,40 +331,40 @@ stats({unsuback, MsgId}, State) ->
     diff(MsgId, State, "mqtt.consumer.unsuback.latency", histogram);
 stats({pubrec_in, MsgId}, State) ->
     T2 = os:timestamp(),
-    T1 = maps:get(MsgId, State),
+    T1 = maps:get({outgoing, MsgId}, State),
     mzb_metrics:notify({"mqtt.publisher.qos2.pub_out_to_pubrec_in.latency", histogram}, positive(timer:now_diff(T2, T1))),
     mzb_metrics:notify({"mqtt.publisher.qos2.pubrec.in.total"}, 1),
-    NewState = maps:update(MsgId, T2, State),
+    NewState = maps:update({outgoing, MsgId}, T2, State),
     NewState;
 stats({pubrec_out, MsgId}, State) ->
-    T2 = maps:get(MsgId, State),
+    T2 = maps:get({incoming, MsgId}, State),
     T3 = os:timestamp(),
     mzb_metrics:notify({"mqtt.consumer.qos2.publish_in_to_pubrec_out.internal_latency", histogram}, positive(timer:now_diff(T3, T2))),
-    NewState = maps:update(MsgId, T3, State),
+    NewState = maps:update({incoming, MsgId}, T3, State),
     NewState;
 stats({pubrel_out, MsgId}, State) ->
     T3 = os:timestamp(),
-    T2 = maps:get(MsgId, State),
+    T2 = maps:get({outgoing, MsgId}, State),
     mzb_metrics:notify({"mqtt.publisher.qos2.pubrec_in_to_pubrel_out.internal_latency", histogram}, positive(timer:now_diff(T3, T2))),
-    NewState = maps:update(MsgId, T3, State),
+    NewState = maps:update({outgoing, MsgId}, T3, State),
     NewState;
 stats({pubrel_in, MsgId}, State) ->
     T4 = os:timestamp(),
-    T3 = maps:get(MsgId, State),
+    T3 = maps:get({incoming, MsgId}, State),
     mzb_metrics:notify({"mqtt.consumer.qos2.pubrec_out_to_pubrel_in.latency", histogram}, positive(timer:now_diff(T4, T3))),
-    NewState = maps:update(MsgId, T4, State),
+    NewState = maps:update({incoming, MsgId}, T4, State),
     NewState;
 stats({pubcomp_in, MsgId}, State) ->
     T4 = os:timestamp(),
-    T3 = maps:get(MsgId, State),
+    T3 = maps:get({outgoing, MsgId}, State),
     mzb_metrics:notify({"mqtt.publisher.qos2.pubrel_out_to_pubcomp_in.latency", histogram}, positive(timer:now_diff(T4, T3))),
-    NewState = maps:remove(MsgId, State),
+    NewState = maps:remove({outgoing, MsgId}, State),
     NewState;
 stats({pubcomp_out, MsgId}, State) ->
     T5 = os:timestamp(),
-    T4 = maps:get(MsgId, State),
+    T4 = maps:get({incoming, MsgId}, State),
     mzb_metrics:notify({"mqtt.consumer.qos2.pubrel_in_to_pubcomp_out.internal_latency", histogram}, positive(timer:now_diff(T5, T4))),
-    NewState = maps:remove(MsgId, State),
+    NewState = maps:remove({incoming, MsgId}, State),
     NewState.
 
 diff(MsgId, State, Metric, MetricType) ->


### PR DESCRIPTION
This change introduces following statements:
* random_client_ip(iface) - return random IP from network
  interface that name matches provided pattern. Can be used
  to mitigate TCP limitation on number of open conenctions.
* publish_to_one(prefix, client_id, payload, qos) - publish
  a message to the topic combined from prefix and client id.
* forward(prefix, qos) - forward received messages to topic
  combined with prefix and a client id of message sender. It
  assumes that message was published to the topic which ends
  with client id (see publish_to_one).
* idle() - do nothing with received messages.