### PR TITLE
Backport fixes from bridge client, extract & pull in type files

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,8 +17,9 @@
 {deps, [
         {lager, ".*",
             {git, "git://github.com/basho/lager.git", {tag, "2.2.3"}}},
-        {vmq_commons, ".*", {git, "git://github.com/erlio/vmq_commons.git", "7b6171b"}}
-        ]}.
+            {vernemq_dev, ".*", {git, "git://github.com/vernemq/vernemq_dev.git", {tag, "master"}}}
+        ]
+        }.
 
 {deps_dir, "./deps"}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,12 @@
+[{<<"goldrush">>,
+  {git,"git://github.com/DeadZen/goldrush.git",
+       {ref,"212299233c7e7eb63a97be2777e1c05ebaa58dbe"}},
+  1},
+ {<<"lager">>,
+  {git,"git://github.com/basho/lager.git",
+       {ref,"1c42c3bffbab49b0f06c9a916b00ca4911ae6a2f"}},
+  0},
+ {<<"vernemq_dev">>,
+  {git,"git://github.com/vernemq/vernemq_dev.git",
+       {ref,"9afa661feaf15f73e2a64cd81166cf335329882e"}},
+  0}].

--- a/src/gen_mqtt.erl
+++ b/src/gen_mqtt.erl
@@ -1,0 +1,751 @@
+%% Copyright 2018 Erlio GmbH Basel Switzerland (http://erl.io)
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(gen_mqtt).
+-behavior(gen_fsm).
+-include("vmq_types.hrl").
+
+-ifdef(nowarn_gen_fsm).
+-compile([{nowarn_deprecated_function,
+          [{gen_fsm,start,3},
+           {gen_fsm,start,4},
+           {gen_fsm,start_link,3},
+           {gen_fsm,start_link,4},
+           {gen_fsm,send_event,2},
+           {gen_fsm,send_all_state_event,2},
+           {gen_fsm,sync_send_all_state_event,2},
+           {gen_fsm,send_event_after,2},
+           {gen_fsm,cancel_timer,1}]}]).
+-endif.
+
+-define(PD_QDROP, pd_queue_drop).
+
+-callback init(Args :: any()) ->
+    {ok, State :: any()} |
+    {ok, State :: any(), Extra :: any()} |
+    {stop, Reason :: any()}.
+-callback handle_call(Req :: any(), From :: any(), State :: any()) ->
+    {reply, Reply :: any(), State :: any()} |
+    {reply, Reply :: any(), State :: any(), Extra :: any()} |
+    {noreply, State :: any()} |
+    {noreply, State :: any(), Extra :: any()} |
+    {stop, Reason :: any(), State :: any()} |
+    {stop, Reason :: any(), Reply :: any(), State :: any()}.
+-callback handle_info(Req :: any(), State :: any()) ->
+    {noreply, State :: any()} |
+    {noreply, State :: any(), Extra :: any()} |
+    {stop, Reason :: any(), State :: any()} |
+    {stop, Reason :: any(), Reply :: any(), State :: any()}.
+-callback handle_cast(Req :: any(), State :: any()) ->
+    {ok, State :: any()} |
+    {ok, State :: any(), Extra :: any()} |
+    {stop, Reason :: any(), State :: any()}.
+-callback terminate(Reason :: any(), State :: any()) ->
+    ok.
+-callback code_change(_OldVsn :: any(), State :: any(), Extra :: any()) ->
+    {ok, State :: any()}.
+-callback on_connect(State :: any()) ->
+    {ok, State :: any()} |
+    {stop, Reason :: any()}.
+-callback on_connect_error(Reason :: any(), State :: any()) ->
+    {ok, State :: any()} |
+    {stop, Reason :: any()}.
+-callback on_disconnect(State :: any()) ->
+    {ok, State :: any()} |
+    {stop, Reason :: any()}.
+-callback on_subscribe(Topics :: [any()], State :: any()) ->
+    {ok, State :: any()} |
+    {stop, Reason :: any()}.
+-callback on_unsubscribe(Topics :: [any()], State :: any()) ->
+    {ok, State :: any()} |
+    {stop, Reason :: any()}.
+-callback on_publish(Topic :: any(), Payload :: binary(), Opts :: map(), State :: any()) ->
+    {ok, State :: any()} |
+    {stop, Reason :: any()}.
+
+
+%startup
+-export([start_link/3,
+         start_link/4,
+         start/3,
+         start/4,
+         info/1,
+         stats/1,
+         subscribe/2,
+         subscribe/3,
+         unsubscribe/2,
+         publish/4,
+         publish/5,
+         disconnect/1,
+         call/2,
+         cast/2]).
+
+
+%% gen_fsm callbacks
+-export([init/1,
+    handle_info/3,
+    handle_event/3,
+    handle_sync_event/4,
+    code_change/4,
+    terminate/3]).
+
+% fsm state
+-export([
+    waiting_for_connack/2,
+    connected/2,
+    connecting/2]).
+
+-define(MQTT_PROTO_MAJOR, 3).
+
+-record(queue, {
+          queue = queue:new() :: queue:queue(),
+          %% max queue size. 0 means disabled.
+          max = 0 :: non_neg_integer(),
+          size = 0 :: non_neg_integer(),
+          drop = 0 :: non_neg_integer()
+         }).
+
+-type queue() :: #queue{}.
+
+-record(state, {host                      :: inet:ip_address(),
+                port                      :: inet:port_number(),
+                sock                      :: undefined | gen_tcp:socket() | ssl:sslsocket(),
+                msgid = 1                 :: non_neg_integer(),
+                username                  :: binary(),
+                password                  :: binary(),
+                client                    :: string() ,
+                clean_session = false     :: boolean(),
+                last_will_topic           :: string() | undefined,
+                last_will_msg             :: string() | undefined,
+                last_will_qos             :: non_neg_integer(),
+                buffer = <<>>             :: binary(),
+                o_queue = #queue{}        :: queue(),
+                waiting_acks = maps:new() :: map(),
+                unacked_msgs = maps:new() :: map(),
+                ping_tref                 :: timer:ref() | undefined,
+                reconnect_timeout,
+                keepalive_interval = 60000,
+                retry_interval = 10000,
+                proto_version = ?MQTT_PROTO_MAJOR,
+                %%
+                mod,
+                mod_state=[],
+                transport,
+                parser = <<>>,
+                info_fun}).
+
+start_link(Module, Args, Opts) ->
+    GenFSMOpts = proplists:get_value(gen_fsm, Opts, []),
+    gen_fsm:start_link(?MODULE, [Module, Args, Opts], GenFSMOpts).
+
+start_link(Name, Module, Args, Opts) ->
+    GenFSMOpts = proplists:get_value(gen_fsm, Opts, []),
+    gen_fsm:start_link(Name, ?MODULE, [Module, Args, Opts], GenFSMOpts).
+
+start(Module, Args, Opts) ->
+    GenFSMOpts = proplists:get_value(gen_fsm, Opts, []),
+    gen_fsm:start(?MODULE, [Module, Args, Opts], GenFSMOpts).
+
+start(Name, Module, Args, Opts) ->
+    GenFSMOpts = proplists:get_value(gen_fsm, Opts, []),
+    gen_fsm:start(Name, ?MODULE, [Module, Args, Opts], GenFSMOpts).
+
+info(Pid) ->
+    gen_fsm:sync_send_all_state_event(Pid, info).
+
+stats(Pid) ->
+    case erlang:process_info(Pid, [dictionary]) of
+        undefined ->
+            undefined;
+        [{dictionary, PD}] ->
+            #{dropped => proplists:get_value(?PD_QDROP, PD, 0)}
+    end.
+
+publish(P, Topic, Payload, Qos) ->
+    publish(P, Topic, Payload, Qos, false).
+
+publish(P, Topic, Payload, Qos, Retain) ->
+    gen_fsm:send_event(P, {publish, {Topic, Payload, Qos, Retain, false}}).
+
+subscribe(P, [T|_] = Topics) when is_tuple(T) ->
+    gen_fsm:send_event(P, {subscribe, Topics}).
+
+subscribe(P, Topic, QoS) ->
+    subscribe(P, [{Topic, QoS}]).
+
+unsubscribe(P, [T|_] = Topics) when is_list(T) ->
+    gen_fsm:send_event(P, {unsubscribe, Topics});
+unsubscribe(P, Topic) ->
+    unsubscribe(P, [Topic]).
+
+disconnect(P) ->
+    gen_fsm:send_event(P, disconnect).
+
+call(P, Req) ->
+    gen_fsm:sync_send_all_state_event(P, Req).
+
+cast(P, Req) ->
+    gen_fsm:send_all_state_event(P, Req).
+
+wrap_res(StateName, init, Args, #state{mod=Mod} = State) ->
+    case erlang:apply(Mod, init, Args) of
+        {ok, ModState} ->
+            {ok, StateName, State#state{mod_state=ModState}};
+        {ok, ModState, Extra} ->
+            {ok, StateName, State#state{mod_state=ModState}, Extra};
+        {stop, Reason} ->
+            {stop, Reason}
+    end;
+wrap_res(StateName, Function, Args, #state{mod=Mod, mod_state=ModState} = State) ->
+    wrap_res(erlang:apply(Mod, Function, Args ++ [ModState]), StateName, State).
+
+wrap_res({ok, ModState}, StateName, State) ->
+    {next_state, StateName, State#state{mod_state=ModState}};
+wrap_res({ok, ModState, Extra}, StateName, State) ->
+    {next_state, StateName, State#state{mod_state=ModState}, Extra};
+wrap_res({stop, Reason}, _StateName, _State) ->
+    {stop, Reason};
+wrap_res({reply, Reply, ModState}, StateName, State) ->
+    {reply, Reply, StateName, State#state{mod_state=ModState}};
+wrap_res({reply, Reply, ModState, Extra}, StateName, State) ->
+    {reply, Reply, StateName, State#state{mod_state=ModState}, Extra};
+wrap_res({noreply, ModState}, StateName, State) ->
+    {next_state, StateName, State#state{mod_state=ModState}};
+wrap_res({noreply, ModState, Extra}, StateName, State) ->
+    {next_state, StateName, State#state{mod_state=ModState}, Extra};
+wrap_res({stop, Reason, ModState}, _StateName, State) ->
+    {stop, Reason, State#state{mod_state=ModState}};
+wrap_res({stop, Reason, Reply, ModState}, _StateName, State) ->
+    {stop, Reason, Reply, State#state{mod_state=ModState}};
+wrap_res({ok}, _StateName, _State) ->
+    ok;
+wrap_res(ok, _StateName, _State) ->
+    ok.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% State Callbacks
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+connecting(connect, State) ->
+    #state{host = Host, port = Port, transport={Transport, Opts}, client=ClientId, info_fun=InfoFun} = State,
+    case Transport:connect(Host, Port, [binary, {packet, raw}|Opts]) of
+        {ok, Sock} ->
+            NewInfoFun = call_info_fun({connect_out, ClientId}, InfoFun),
+            NewState = State#state{sock=Sock, buffer= <<>>, info_fun=NewInfoFun},
+            send_connect(NewState),
+            active_once(Transport, Sock),
+            {next_state, waiting_for_connack, NewState};
+        {error, _Reason} ->
+            error_logger:error_msg("connection to ~p:~p failed due to ~p", [Host, Port, _Reason]),
+            gen_fsm:send_event_after(3000, connect),
+            wrap_res(connecting, on_connect_error, [server_not_found], State)
+    end;
+connecting(disconnect, State) ->
+    {stop,  normal, State};
+connecting({publish, PubReq}, State) ->
+    NewState = maybe_queue_outgoing(PubReq, State),
+    {next_state, connecting, NewState};
+connecting(_Event, State) ->
+    {next_state, connecting, State}.
+
+waiting_for_connack({publish, PubReq}, State) ->
+    NewState = maybe_queue_outgoing(PubReq, State),
+    {next_state, waiting_for_connack, NewState};
+waiting_for_connack(_Event, State) ->
+    {next_state, waiting_for_connack, State}.
+
+connected({subscribe, Topics} = Msg, State=#state{transport={Transport,_}, msgid=MsgId,
+    sock=Sock, info_fun=InfoFun}) ->
+    Frame = #mqtt_subscribe{
+        message_id = MsgId,
+        topics = Topics
+    },
+    NewInfoFun = call_info_fun({subscribe_out, MsgId}, InfoFun),
+    send_frame(Transport, Sock, Frame),
+    Key = {subscribe, MsgId},
+    {next_state, connected, retry(Key, Msg,
+                                  State#state{msgid='++'(MsgId),
+                                              info_fun=NewInfoFun})};
+
+connected({unsubscribe, Topics} = Msg, State=#state{transport={Transport, _}, sock=Sock,
+    msgid=MsgId, info_fun=InfoFun}) ->
+    Frame = #mqtt_unsubscribe{
+        message_id = MsgId,
+        topics = Topics
+    },
+    NewInfoFun = call_info_fun({unsubscribe_out, MsgId}, InfoFun),
+    send_frame(Transport, Sock, Frame),
+    Key = {unsubscribe, MsgId},
+    {next_state, connected, retry(Key, Msg,
+                                  State#state{msgid='++'(MsgId),
+                                              info_fun=NewInfoFun})};
+
+connected({publish, PubReq}, State) ->
+    {next_state, connected, send_publish(PubReq, State)};
+
+connected({retry, Key}, State) ->
+    {next_state, connected, handle_retry(Key, State)};
+
+connected({ack, _MsgId}, State) ->
+    {next_state, connected, State};
+
+connected(ping, #state{transport={Transport, _}, sock=Sock,
+    keepalive_interval=Int} = State) ->
+    send_ping(Transport, Sock),
+    Ref = gen_fsm:send_event_after(Int, ping),
+    {next_state, connected, State#state{ping_tref=Ref}};
+
+connected(disconnect, State=#state{transport={Transport, _}, sock=Sock}) ->
+    send_disconnect(Transport, Sock),
+    {stop, normal, State};
+
+connected(maybe_reconnect, State) ->
+    maybe_reconnect(on_disconnect, [], State);
+
+connected(_Event, State) ->
+    {stop, unknown_event, State}.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% gen_fsm callbacks
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+init([Mod, Args, Opts]) ->
+    Host = proplists:get_value(host, Opts, "localhost"),
+    Port = proplists:get_value(port, Opts, 1883),
+    Username = proplists:get_value(username, Opts, undefined),
+    Password = proplists:get_value(password, Opts, undefined),
+    ClientId = proplists:get_value(client, Opts, "vmq-bridge"),
+    CleanSession = proplists:get_value(clean_session, Opts, true),
+    LWTopic = proplists:get_value(last_will_topic, Opts, undefined),
+    LWMsg = proplists:get_value(last_will_msg, Opts, undefined),
+    LWQos = proplists:get_value(last_will_qos, Opts, 0),
+    ReconnectTimeout = proplists:get_value(reconnect_timeout, Opts, undefined),
+    KeepAliveInterval = proplists:get_value(keepalive_interval, Opts, 60),
+    RetryInterval = proplists:get_value(retry_interval, Opts, 10),
+    ProtoVer = proplists:get_value(proto_version, Opts, ?MQTT_PROTO_MAJOR),
+    InfoFun = proplists:get_value(info_fun, Opts, {fun(_,_) -> ok end, []}),
+    MaxQueueSize = proplists:get_value(max_queue_size, Opts, 0),
+    {Transport, TransportOpts} = proplists:get_value(transport, Opts, {gen_tcp, []}),
+
+    State = #state{host = Host, port = Port, proto_version=ProtoVer,
+        username = Username, password = Password, client=ClientId, mod=Mod,
+        clean_session=CleanSession, last_will_topic=LWTopic, last_will_msg=LWMsg, last_will_qos=LWQos,
+        reconnect_timeout=case ReconnectTimeout of undefined -> undefined; _ -> 1000 * ReconnectTimeout end,
+        keepalive_interval=1000 * KeepAliveInterval,
+        retry_interval=1000* RetryInterval, transport={Transport, TransportOpts},
+        o_queue = #queue{max=MaxQueueSize},
+        info_fun=InfoFun},
+    Res = wrap_res(connecting, init, [Args], State),
+    gen_fsm:send_event_after(0, connect),
+    Res.
+
+handle_info({ssl, Socket, Bin}, StateName, #state{sock=Socket} = State) ->
+    #state{transport={Transport, _}, buffer=Buffer} = State,
+    active_once(Transport, Socket),
+    process_bytes(<<Buffer/binary, Bin/binary>>, StateName, State);
+handle_info({tcp, Socket, Bin}, StateName, #state{sock=Socket} = State) ->
+    #state{transport={Transport, _}, buffer=Buffer} = State,
+    active_once(Transport, Socket),
+    process_bytes(<<Buffer/binary, Bin/binary>>, StateName, State);
+
+
+handle_info({ssl_closed, Sock}, _, State=#state{sock=Sock, reconnect_timeout=undefined}) ->
+    {stop, normal, State};
+handle_info({ssl_closed, Sock}, _, State=#state{sock=Sock, reconnect_timeout=Timeout}) ->
+    gen_fsm:send_event_after(Timeout, connect),
+    wrap_res(connecting, on_disconnect, [], cleanup_session(State#state{sock=undefined}));
+handle_info({ssl_error, Sock, _}, _, State=#state{sock=Sock, reconnect_timeout=undefined}) ->
+    {stop, normal, State};
+handle_info({ssl_error, Sock, _}, _, State=#state{sock=Sock, reconnect_timeout=Timeout}) ->
+    gen_fsm:send_event_after(Timeout, connect),
+    wrap_res(connecting, on_disconnect, [], cleanup_session(State#state{sock=undefined}));
+handle_info({tcp_closed, Sock}, _, State=#state{sock=Sock, reconnect_timeout=undefined}) ->
+    {stop, normal, State};
+handle_info({tcp_closed, Sock}, _, State=#state{sock=Sock, reconnect_timeout=Timeout}) ->
+    gen_fsm:send_event_after(Timeout, connect),
+    wrap_res(connecting, on_disconnect, [], cleanup_session(State#state{sock=undefined}));
+handle_info({tcp_error, Sock, _Error}, _, State=#state{sock=Sock, reconnect_timeout=undefined}) ->
+    {stop, normal, State};
+handle_info({tcp_error, Sock, _}, _, State=#state{sock=Sock, reconnect_timeout=Timeout}) ->
+    gen_fsm:send_event_after(Timeout, connect),
+    wrap_res(connecting, on_disconnect, [], cleanup_session(State#state{sock=undefined}));
+
+handle_info(Info, StateName, State) ->
+    wrap_res(StateName, handle_info, [Info], State).
+
+process_bytes(Bytes, StateName, #state{parser=ParserState} = State) ->
+    Data = <<ParserState/binary, Bytes/binary>>,
+    case vmq_parser:parse(Data) of
+        {error, _Reason} ->
+            {next_state, StateName, State#state{parser= <<>>}};
+        more ->
+            {next_state, StateName, State#state{parser=Data}};
+        {Frame, Rest} ->
+            {next_state, NextStateName, NewState}
+                = handle_frame(StateName, Frame, State),
+            process_bytes(Rest, NextStateName, NewState#state{parser= <<>>})
+    end.
+
+handle_frame(waiting_for_connack, #mqtt_connack{return_code=ReturnCode}, State0) ->
+    #state{client=ClientId, info_fun=InfoFun} = State0,
+    case ReturnCode of
+        ?CONNACK_ACCEPT ->
+            NewInfoFun = call_info_fun({connack_in, ClientId}, InfoFun),
+            State1 = resume_wacks_retry(State0),
+            State2 = maybe_publish_offline_msgs(State1),
+            wrap_res(connected, on_connect, [], start_ping_timer(State2#state{info_fun=NewInfoFun}));
+        ?CONNACK_PROTO_VER ->
+            maybe_reconnect(on_connect_error, [wrong_protocol_version], State0);
+        ?CONNACK_INVALID_ID ->
+            maybe_reconnect(on_connect_error, [invalid_id], State0);
+        ?CONNACK_SERVER ->
+            maybe_reconnect(on_connect_error, [server_not_available], State0);
+        ?CONNACK_CREDENTIALS ->
+            maybe_reconnect(on_connect_error, [invalid_credentials], State0);
+        ?CONNACK_AUTH ->
+            maybe_reconnect(on_connect_error, [not_authorized], State0)
+    end;
+
+handle_frame(connected, #mqtt_suback{message_id=MsgId, qos_table=QoSTable}, State0) ->
+    #state{info_fun=InfoFun} = State0,
+    Key = {subscribe, MsgId},
+    case cancel_retry_and_get(Key, State0) of
+        {ok, {{subscribe, Topics}, State1}} ->
+            NewInfoFun = call_info_fun({suback, MsgId}, InfoFun),
+            {TopicNames, _} = lists:unzip(Topics),
+            case length(TopicNames) == length(QoSTable) of
+                true ->
+                    wrap_res(connected, on_subscribe, [lists:zip(TopicNames, QoSTable)],
+                             State1#state{info_fun=NewInfoFun});
+                false ->
+                    wrap_res(connected, on_subscribe, [{error, Topics, QoSTable}],
+                             State1#state{info_fun=NewInfoFun})
+            end;
+        {error, not_found} ->
+            {next_state, connected, State0}
+    end;
+
+handle_frame(connected, #mqtt_unsuback{message_id=MsgId}, State0) ->
+    #state{info_fun=InfoFun} = State0,
+    Key = {unsubscribe, MsgId},
+    case cancel_retry_and_get(Key, State0) of
+        {ok, {{unsubscribe, Topics}, State1}} ->
+            NewInfoFun = call_info_fun({unsuback, MsgId}, InfoFun),
+            wrap_res(connected, on_unsubscribe, [Topics],
+                State1#state{info_fun=NewInfoFun});
+        {error, not_found} ->
+            {next_state, connected, State0}
+    end;
+
+handle_frame(connected, #mqtt_puback{message_id=MessageId}, State0) ->
+    #state{info_fun=InfoFun} = State0,
+    %% qos1 flow
+    Key = {publish, MessageId},
+    case cancel_retry_and_get(Key, State0) of
+        {ok, {#mqtt_publish{}, State1}} ->
+            NewInfoFun = call_info_fun({puback_in, MessageId}, InfoFun),
+            {next_state, connected, State1#state{info_fun=NewInfoFun}};
+        {error, not_found} ->
+            {next_state, connected, State0}
+    end;
+
+handle_frame(connected, #mqtt_pubrec{message_id=MessageId}, State0) ->
+    #state{transport={Transport, _}, sock=Socket, info_fun=InfoFun} = State0,
+    %% qos2 flow
+    Key = {publish, MessageId},
+    case cancel_retry_and_get(Key, State0) of
+        {ok, {_Publish, State1}} ->
+            NewInfoFun0 = call_info_fun({pubrec_in, MessageId}, InfoFun),
+            NewKey = {pubrel, MessageId},
+            PubRelFrame = #mqtt_pubrel{message_id=MessageId},
+            send_frame(Transport, Socket, PubRelFrame),
+            NewInfoFun1 = call_info_fun({pubrel_out, MessageId}, NewInfoFun0),
+            {next_state, connected, retry(NewKey, PubRelFrame, State1#state{info_fun=NewInfoFun1})};
+        {error, not_found} ->
+            {next_state, connected, State0}
+    end;
+
+handle_frame(connected, #mqtt_pubrel{message_id=MessageId}, State0) ->
+    #state{transport={Transport,_}, sock=Socket, info_fun=InfoFun} = State0,
+    %% qos2 flow
+    case get_remove_unacked_msg(MessageId, State0) of
+        {ok, {{Topic, Payload, Opts}, State1}} ->
+            NewInfoFun0 = call_info_fun({pubrel_in, MessageId}, InfoFun),
+            {next_state, connected, State2} = wrap_res(connected, on_publish, [Topic, Payload, Opts], State1),
+            NewInfoFun1 = call_info_fun({pubcomp_out, MessageId}, NewInfoFun0),
+            PubCompFrame = #mqtt_pubcomp{message_id=MessageId},
+            send_frame(Transport, Socket, PubCompFrame),
+            {next_state, connected, State2#state{info_fun=NewInfoFun1}};
+        error ->
+            {next_state, connected, State0}
+    end;
+
+handle_frame(connected, #mqtt_pubcomp{message_id=MessageId}, State0) ->
+    #state{info_fun=InfoFun} = State0,
+    %% qos2 flow
+    Key = {pubrel, MessageId},
+    case cancel_retry_and_get(Key, State0) of
+        {ok, {#mqtt_pubrel{}, State1}} ->
+            NewInfoFun = call_info_fun({pubcomp_in, MessageId}, InfoFun),
+            {next_state, connected, State1#state{info_fun=NewInfoFun}};
+        {error, not_found} ->
+            {next_state, connected, State0}
+    end;
+
+handle_frame(connected, #mqtt_publish{message_id=MessageId, topic=Topic,
+    qos=QoS, payload=Payload, retain=Retain, dup=Dup}, State) ->
+    #state{transport={Transport, _}, sock=Socket, info_fun=InfoFun} = State,
+    NewInfoFun = call_info_fun({publish_in, MessageId, Payload, QoS}, InfoFun),
+    Opts = #{qos => QoS,
+             retain => unflag(Retain),
+             dup => unflag(Dup)},
+    case QoS of
+        0 ->
+            wrap_res(connected, on_publish, [Topic, Payload, Opts], State#state{info_fun=NewInfoFun});
+        1 ->
+            PubAckFrame = #mqtt_puback{message_id=MessageId},
+            NewInfoFun1 = call_info_fun({puback_out, MessageId}, NewInfoFun),
+            Res = wrap_res(connected, on_publish, [Topic, Payload, Opts], State#state{info_fun=NewInfoFun1}),
+            send_frame(Transport, Socket, PubAckFrame),
+            Res;
+        2 ->
+            PubRecFrame = #mqtt_pubrec{message_id=MessageId},
+            NewInfoFun1 = call_info_fun({pubrec_out, MessageId}, NewInfoFun),
+            send_frame(Transport, Socket, PubRecFrame),
+            {next_state, connected, store_unacked_msg(MessageId, {Topic, Payload, Opts},
+                                                          State#state{info_fun=NewInfoFun1})}
+    end;
+
+handle_frame(connected, #mqtt_pingresp{}, State) ->
+    {next_state, connected, State};
+
+handle_frame(connected, #mqtt_disconnect{}, #state{transport={Transport, _}} = State) ->
+    Transport:close(State#state.sock),
+    gen_fsm:send_event_after(5000, connect),
+    wrap_res(connecting, on_disconnect, [], cleanup_session(State#state{sock=undefined})).
+
+handle_event(Event, StateName, State) ->
+    wrap_res(StateName, handle_cast, [Event], State).
+
+handle_sync_event(info, _From, StateName,
+                  #state{o_queue=#queue{size=Size,drop=Drop,max=Max}}=State) ->
+    Info =
+        #{out_queue_size=>Size,
+          out_queue_dropped=>Drop,
+          out_queue_max_size=>Max},
+    {reply, {ok, Info}, StateName, State};
+handle_sync_event(Req, From, StateName, State) ->
+    wrap_res(StateName, handle_call, [Req, From], State).
+
+terminate(Reason, StateName, State) ->
+    wrap_res(StateName, terminate, [Reason], State).
+
+code_change(OldVsn, StateName, State, Extra) ->
+    #state{mod=Mod, mod_state=ModState} = State,
+    {ok, NewModState} = erlang:apply(Mod, code_change, [OldVsn, ModState, Extra]),
+    {ok, StateName, State#state{mod_state=NewModState}}.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% INTERNAL
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+send_connect(State= #state{transport={Transport, _}, sock=Sock, username=Username, password=Password, client=ClientId,
+    clean_session=CleanSession, last_will_topic=LWTopic, last_will_msg=LWMsg,
+    last_will_qos=LWQoS, proto_version=ProtoVer, keepalive_interval=Int}) ->
+    Frame = #mqtt_connect{
+        proto_ver = ProtoVer,
+        username = Username,
+        password = Password,
+        clean_session = CleanSession,
+        keep_alive = Int div 1000,
+        client_id = list_to_binary(ClientId),
+        will_retain = (LWTopic /= undefined) and (LWMsg /= undefined),
+        will_qos   = case (LWTopic /= undefined) and (LWMsg /= undefined) of
+                         true when is_integer(LWQoS) -> LWQoS;
+                         _ -> 0
+                     end,
+        will_topic = LWTopic,
+        will_msg = LWMsg
+    },
+    send_frame(Transport, Sock, Frame),
+    State.
+
+send_publish({Topic, Payload, QoS, Retain, Dup}, #state{msgid=MsgId} = State) ->
+    send_publish(MsgId, Topic, Payload, QoS, Retain, Dup, State#state{msgid='++'(MsgId)});
+send_publish({MsgId, Topic, Payload, QoS, Retain, _}, State) ->
+    %% called in case of retry
+    send_publish(MsgId, Topic, Payload, QoS, Retain, true, State).
+
+send_publish(MsgId, Topic, Payload, QoS, Retain, Dup, State) ->
+    #state{transport={Transport, _}, sock = Sock, info_fun=InfoFun} = State,
+    Frame = #mqtt_publish{
+        message_id = if QoS == 0 ->
+            undefined;
+                         true ->
+                             MsgId
+                     end,
+        topic = Topic,
+        qos = QoS,
+        retain = Retain,
+        dup = Dup,
+        payload = Payload
+    },
+    NewInfoFun = call_info_fun({publish_out, MsgId, QoS}, InfoFun),
+    send_frame(Transport, Sock, Frame),
+    case QoS of
+        0 ->
+            State#state{info_fun=NewInfoFun};
+        _ ->
+            Key = {publish, MsgId},
+            retry(Key, Frame#mqtt_publish{dup=true}, State#state{info_fun=NewInfoFun})
+    end.
+
+send_disconnect(Transport, Sock) ->
+    send_frame(Transport, Sock, #mqtt_disconnect{}).
+
+send_ping(Transport, Sock) ->
+    send_frame(Transport, Sock, #mqtt_pingreq{}).
+
+send_frame(Transport, Sock, Frame) ->
+    case Transport:send(Sock, vmq_parser:serialise(Frame)) of
+        ok ->
+            ok;
+        {error, _} ->
+            gen_fsm:send_event(self(), maybe_reconnect)
+    end.
+
+maybe_reconnect(Fun, Args, #state{client=ClientId, reconnect_timeout=Timeout, transport={Transport,_}, info_fun=InfoFun} = State) ->
+    case Timeout of
+        undefined ->
+            {stop, normal, State};
+        _ ->
+            Transport:close(State#state.sock),
+            gen_fsm:send_event_after(Timeout, connect),
+            NewInfoFun = call_info_fun({reconnect, ClientId}, InfoFun),
+            wrap_res(connecting, Fun, Args,
+                     cleanup_session(State#state{sock=undefined, info_fun=NewInfoFun}))
+    end.
+
+maybe_queue_outgoing(_PubReq, #state{o_queue=#queue{max=0}}=State) ->
+    %% queue is disabled
+    State;
+maybe_queue_outgoing(PubReq, #state{o_queue=#queue{size=Size,max=Max}=Q}=State)
+  when Size < Max ->
+    State#state{o_queue=queue_outgoing(PubReq, Q)};
+maybe_queue_outgoing(_PubReq, #state{o_queue=Q}=State) ->
+    %% drop!
+    State#state{o_queue=drop(Q)}.
+
+queue_outgoing(Msg, #queue{size=Size, queue=QQ} = Q) ->
+    Q#queue{size=Size+1, queue=queue:in(Msg,QQ)}.
+
+maybe_publish_offline_msgs(#state{o_queue=#queue{size=Size} = Q} = State) when Size > 0 ->
+    publish_from_queue(Q, State);
+maybe_publish_offline_msgs(State) -> State.
+
+publish_from_queue(#queue{size=Size, queue=QQ} = Q, State0) when Size > 0 ->
+    {{value, PubReq}, NewQQ} = queue:out(QQ),
+    State1 = send_publish(PubReq, State0),
+    maybe_publish_offline_msgs(State1#state{o_queue=Q#queue{size=Size-1, queue=NewQQ}}).
+
+drop(#queue{drop=D}=Q) ->
+    put(?PD_QDROP, D+1),
+    Q#queue{drop=D+1}.
+
+handle_retry(Key, #state{transport={Transport,_}, sock=Sock, waiting_acks=WAcks} = State) ->
+    case maps:find(Key, WAcks) of
+        error ->
+            State;
+        {ok, {_Ref, #mqtt_publish{} = Frame}} ->
+            send_frame(Transport, Sock, Frame#mqtt_publish{dup = true}),
+            retry(Key, Frame, State);
+        {ok, {_Ref, #mqtt_pubrel{} = Frame}} ->
+            send_frame(Transport, Sock, Frame),
+            retry(Key, Frame, State);
+        {ok, {_Ref, Msg}} ->
+            gen_fsm:send_event(self(), Msg),
+            State#state{waiting_acks=maps:remove(Key, WAcks)}
+    end.
+
+retry(Key, Message, #state{retry_interval=RetryInterval, waiting_acks=WAcks} = State) ->
+    NewRef = gen_fsm:send_event_after(RetryInterval, {retry, Key}),
+    NewWAcks = maps:remove(Key, WAcks),
+    State#state{waiting_acks=maps:put(Key, {NewRef, Message}, NewWAcks)}.
+
+cancel_retry_and_get(Key, #state{waiting_acks=WAcks} = State) ->
+    case maps:find(Key, WAcks) of
+        {ok, {Ref, Val}} ->
+            gen_fsm:cancel_timer(Ref),
+            {ok, {Val, State#state{waiting_acks=maps:remove(Key, WAcks)}}};
+        error ->
+            {error, not_found}
+    end.
+
+cleanup_session(State0) ->
+    State1 = cancel_wacks_retry(State0),
+    State2 = cancel_ping_timer(State1),
+    cleanup_unacked_msgs(State2).
+
+cancel_wacks_retry(#state{waiting_acks=WAcks} = State) ->
+    _ = maps:map(fun(_Key, {Ref, _Msg}) ->
+                         gen_fsm:cancel_timer(Ref)
+                 end, WAcks),
+    case State#state.clean_session of
+        true ->
+            State#state{waiting_acks=maps:new()};
+        false ->
+            State
+    end.
+
+resume_wacks_retry(#state{waiting_acks=WAcks} = State) ->
+    maps:fold(fun(Key, _, AccState) ->
+                      handle_retry(Key, AccState)
+              end, State, WAcks).
+
+start_ping_timer(#state{keepalive_interval=0} = State) -> State;
+start_ping_timer(#state{keepalive_interval=Int} = State) ->
+    Ref = gen_fsm:send_event_after(Int, ping), % initial ping trigger
+    State#state{ping_tref=Ref}.
+
+cancel_ping_timer(#state{ping_tref=undefined} = State) -> State;
+cancel_ping_timer(#state{ping_tref=Tref} = State) ->
+    gen_fsm:cancel_timer(Tref),
+    State#state{ping_tref=undefined}.
+
+cleanup_unacked_msgs(#state{clean_session=true} = State) ->
+    State#state{unacked_msgs=maps:new()};
+cleanup_unacked_msgs(State) -> State.
+
+store_unacked_msg(MessageId, {_Topic, _Payload, _Opts} = Msg, #state{unacked_msgs=UnackedMsgs} = State) ->
+    State#state{unacked_msgs=maps:put(MessageId, Msg, UnackedMsgs)}.
+
+get_remove_unacked_msg(MessageId, #state{unacked_msgs=UnackedMsgs} = State) ->
+    case maps:find(MessageId, UnackedMsgs) of
+        {ok, {_Topic, _Payload, _Opts} = Msg} ->
+            {ok, {Msg, State#state{unacked_msgs=maps:remove(MessageId, UnackedMsgs)}}};
+        _ ->
+            error
+    end.
+
+'++'(65535) -> 1;
+'++'(N) -> N + 1.
+
+active_once(gen_tcp, Sock) ->
+    ok = inet:setopts(Sock, [{active, once}]);
+active_once(ssl, Sock) ->
+    ok = ssl:setopts(Sock, [{active, once}]).
+
+call_info_fun(Info, {Fun, FunState}) ->
+    {Fun, Fun(Info, FunState)}.
+
+unflag(0) -> false;
+unflag(1) -> true.

--- a/src/vmq_parser.erl
+++ b/src/vmq_parser.erl
@@ -1,0 +1,439 @@
+-module(vmq_parser).
+-include("vmq_types.hrl").
+-export([parse/1, parse/2, serialise/1]).
+
+-dialyzer({no_match, utf8/1}).
+
+-export([gen_connect/2,
+         gen_connack/0,
+         gen_connack/1,
+         gen_connack/2,
+         gen_publish/4,
+         gen_puback/1,
+         gen_pubrec/1,
+         gen_pubrel/1,
+         gen_pubcomp/1,
+         gen_subscribe/2,
+         gen_subscribe/3,
+         gen_suback/2,
+         gen_unsubscribe/2,
+         gen_unsuback/1,
+         gen_pingreq/0,
+         gen_pingresp/0,
+         gen_disconnect/0]).
+
+%% frame types
+-define(CONNECT,      1).
+-define(CONNACK,      2).
+-define(PUBLISH,      3).
+-define(PUBACK,       4).
+-define(PUBREC,       5).
+-define(PUBREL,       6).
+-define(PUBCOMP,      7).
+-define(SUBSCRIBE,    8).
+-define(SUBACK,       9).
+-define(UNSUBSCRIBE, 10).
+-define(UNSUBACK,    11).
+-define(PINGREQ,     12).
+-define(PINGRESP,    13).
+-define(DISCONNECT,  14).
+
+-define(RESERVED, 0).
+-define(PROTOCOL_MAGIC_31, <<"MQIsdp">>).
+-define(PROTOCOL_MAGIC_311, <<"MQTT">>).
+-define(MAX_LEN, 16#fffffff).
+-define(HIGHBIT, 2#10000000).
+-define(LOWBITS, 2#01111111).
+
+-define(MAX_PACKET_SIZE, 268435455).
+
+-spec parse(binary()) -> {mqtt_frame(), binary()} | {error, atom()} | {{error, atom()}, any()} |more.
+parse(Data) ->
+    parse(Data, ?MAX_PACKET_SIZE).
+
+-spec parse(binary(), non_neg_integer()) ->  {mqtt_frame(), binary()} | {error, atom()} | more.
+parse(<<Fixed:1/binary, 0:1, DataSize:7, Data/binary>>, MaxSize)->
+    parse(DataSize, MaxSize, Fixed, Data);
+parse(<<Fixed:1/binary, 1:1, L1:7, 0:1, L2:7, Data/binary>>, MaxSize) ->
+    parse(L1 + (L2 bsl 7), MaxSize, Fixed, Data);
+parse(<<Fixed:1/binary, 1:1, L1:7, 1:1, L2:7, 0:1, L3:7, Data/binary>>, MaxSize) ->
+    parse(L1 + (L2 bsl 7) + (L3 bsl 14), MaxSize, Fixed, Data);
+parse(<<Fixed:1/binary, 1:1, L1:7, 1:1, L2:7, 1:1, L3:7, 0:1, L4:7, Data/binary>>, MaxSize) ->
+    parse(L1 + (L2 bsl 7) + (L3 bsl 14) + (L4 bsl 21), MaxSize, Fixed, Data);
+parse(<<_:8/binary, _/binary>>, _) ->
+    {error, cant_parse_fixed_header};
+parse(_, _) ->
+    more.
+
+parse(DataSize, 0, Fixed, Data) when byte_size(Data) >= DataSize ->
+    %% no max size limit
+    <<Var:DataSize/binary, Rest/binary>> = Data,
+    {variable(Fixed, Var), Rest};
+parse(DataSize, 0, _Fixed, Data) when byte_size(Data) < DataSize ->
+    more;
+parse(DataSize, MaxSize, Fixed, Data)
+  when byte_size(Data) >= DataSize,
+       byte_size(Data) =< MaxSize ->
+    <<Var:DataSize/binary, Rest/binary>> = Data,
+    {variable(Fixed, Var), Rest};
+parse(DataSize, MaxSize, _, _)
+  when DataSize > MaxSize ->
+    {error, packet_exceeds_max_size};
+parse(_, _, _, _) -> more.
+
+
+-spec variable(binary(), binary()) -> mqtt_frame() | {error, atom()}.
+variable(<<?PUBLISH:4, Dup:1, 0:2, Retain:1>>, <<TopicLen:16/big, Topic:TopicLen/binary, Payload/binary>>) ->
+    case vmq_topic:validate_topic(publish, Topic) of
+        {ok, ParsedTopic} ->
+            #mqtt_publish{dup=Dup,
+                          retain=Retain,
+                          topic=ParsedTopic,
+                          qos=0,
+                          payload=Payload};
+        {error, Reason} ->
+            {error, Reason}
+    end;
+variable(<<?PUBLISH:4, Dup:1, QoS:2, Retain:1>>, <<TopicLen:16/big, Topic:TopicLen/binary, MessageId:16/big, Payload/binary>>)
+  when QoS < 3 ->
+    case vmq_topic:validate_topic(publish, Topic) of
+        {ok, ParsedTopic} ->
+            #mqtt_publish{dup=Dup,
+                          retain=Retain,
+                          topic=ParsedTopic,
+                          qos=QoS,
+                          message_id=MessageId,
+                          payload=Payload};
+        {error, Reason} ->
+            {error, Reason}
+    end;
+variable(<<?PUBACK:4, 0:4>>, <<MessageId:16/big>>) ->
+    #mqtt_puback{message_id=MessageId};
+variable(<<?PUBREC:4, 0:4>>, <<MessageId:16/big>>) ->
+    #mqtt_pubrec{message_id=MessageId};
+variable(<<?PUBREL:4, 0:2, 1:1, 0:1>>, <<MessageId:16/big>>) ->
+    #mqtt_pubrel{message_id=MessageId};
+variable(<<?PUBCOMP:4, 0:4>>, <<MessageId:16/big>>) ->
+    #mqtt_pubcomp{message_id=MessageId};
+variable(<<?SUBSCRIBE:4, 0:2, 1:1, 0:1>>, <<MessageId:16/big, Topics/binary>>) ->
+    case parse_topics(Topics, ?SUBSCRIBE, []) of
+        {ok, ParsedTopics} ->
+            #mqtt_subscribe{topics=ParsedTopics,
+                            message_id=MessageId};
+        E -> E
+    end;
+variable(<<?UNSUBSCRIBE:4, 0:2, 1:1, 0:1>>, <<MessageId:16/big, Topics/binary>>) ->
+    case parse_topics(Topics, ?UNSUBSCRIBE, []) of
+        {ok, ParsedTopics} ->
+            #mqtt_unsubscribe{topics=ParsedTopics,
+                              message_id=MessageId};
+        E ->
+            E
+    end;
+variable(<<?SUBACK:4, 0:4>>, <<MessageId:16/big, Acks/binary>>) ->
+    #mqtt_suback{qos_table=parse_acks(Acks, []),
+                 message_id=MessageId};
+variable(<<?UNSUBACK:4, 0:4>>, <<MessageId:16/big>>) ->
+    #mqtt_unsuback{message_id=MessageId};
+variable(<<?CONNECT:4, 0:4>>, <<L:16/big, PMagic:L/binary, _/binary>>)
+  when not ((PMagic == ?PROTOCOL_MAGIC_311) or
+             (PMagic == ?PROTOCOL_MAGIC_31)) ->
+    {error, unknown_protocol_magic};
+variable(<<?CONNECT:4, 0:4>>,
+    <<L:16/big, _:L/binary, ProtoVersion:8,
+      UserNameFlag:1, PasswordFlag:1, WillRetain:1, WillQos:2, WillFlag:1,
+      CleanSession:1,
+      0:1,  % reserved
+      KeepAlive: 16/big,
+      ClientIdLen:16/big, ClientId:ClientIdLen/binary, Rest0/binary>>) ->
+
+    Conn0 = #mqtt_connect{proto_ver=ProtoVersion,
+                          clean_session=CleanSession,
+                          keep_alive=KeepAlive,
+                          client_id=ClientId},
+
+    case parse_last_will_topic(Rest0, WillFlag, WillRetain, WillQos, Conn0) of
+        {ok, Rest1, Conn1} ->
+            case parse_username(Rest1, UserNameFlag, Conn1) of
+                {ok, Rest2, Conn2} ->
+                    case parse_password(Rest2, UserNameFlag, PasswordFlag, Conn2) of
+                        {ok, <<>>, Conn3} ->
+                            Conn3;
+                        {ok, _, _} ->
+                            {error, invalid_rest_of_binary};
+                        E -> E
+                    end;
+                E -> E
+            end;
+        E -> E
+    end;
+variable(<<?CONNACK:4, 0:4>>, <<0:7, SP:1, ReturnCode:8/big>>) ->
+    #mqtt_connack{session_present=SP, return_code=ReturnCode};
+variable(<<?PINGREQ:4, 0:4>>, <<>>) ->
+    #mqtt_pingreq{};
+variable(<<?PINGRESP:4, 0:4>>, <<>>) ->
+    #mqtt_pingresp{};
+variable(<<?DISCONNECT:4, 0:4>>, <<>>) ->
+    #mqtt_disconnect{};
+variable(_, _) -> {error, cant_parse_variable_header}.
+
+parse_last_will_topic(Rest, 0, 0, 0, Conn) -> {ok, Rest, Conn};
+parse_last_will_topic(<<WillTopicLen:16/big, WillTopic:WillTopicLen/binary,
+                        WillMsgLen:16/big, WillMsg:WillMsgLen/binary,
+                        Rest/binary>>, 1, Retain, QoS, Conn) ->
+    case vmq_topic:validate_topic(publish, WillTopic) of
+        {ok, ParsedTopic} ->
+            {ok, Rest, Conn#mqtt_connect{will_msg=WillMsg,
+                                         will_topic=ParsedTopic,
+                                         will_retain=Retain,
+                                         will_qos=QoS}};
+        _ ->
+            {error, cant_validate_last_will_topic}
+    end;
+parse_last_will_topic(_, _, _, _,_) ->
+    {error, cant_parse_last_will}.
+
+parse_username(Rest, 0, Conn) -> {ok, Rest, Conn};
+parse_username(<<Len:16/big, UserName:Len/binary, Rest/binary>>, 1, Conn) ->
+    {ok, Rest, Conn#mqtt_connect{username=UserName}};
+parse_username(_, 1, _) ->
+    {error, cant_parse_username}.
+
+parse_password(Rest, _, 0, Conn) -> {ok, Rest, Conn};
+parse_password(<<Len:16/big, Password:Len/binary, Rest/binary>>, 1, 1, Conn) ->
+    {ok, Rest, Conn#mqtt_connect{password=Password}};
+parse_password(_, 0, 1, _) ->
+    {error, username_flag_not_set};
+parse_password(_, _, 1, _) ->
+    {error, cant_parse_password}.
+
+
+parse_topics(<<>>, _, []) -> {error, no_topic_provided};
+parse_topics(<<>>, _, Topics) -> {ok, Topics};
+parse_topics(<<L:16/big, Topic:L/binary, 0:6, QoS:2, Rest/binary>>, ?SUBSCRIBE = Sub, Acc)
+  when (QoS >= 0) and (QoS < 3) ->
+    case vmq_topic:validate_topic(subscribe, Topic) of
+        {ok, ParsedTopic} ->
+            parse_topics(Rest, Sub, [{ParsedTopic, QoS}|Acc]);
+        E -> E
+    end;
+parse_topics(<<L:16/big, Topic:L/binary, Rest/binary>>, ?UNSUBSCRIBE = Sub, Acc) ->
+    case vmq_topic:validate_topic(subscribe, Topic) of
+        {ok, ParsedTopic} ->
+            parse_topics(Rest, Sub, [ParsedTopic|Acc]);
+        E -> E
+    end;
+parse_topics(_, _, _) -> {error, cant_parse_topics}.
+
+parse_acks(<<>>, Acks) ->
+    Acks;
+parse_acks(<<128:8, Rest/binary>>, Acks) ->
+    parse_acks(Rest, [not_allowed | Acks]);
+parse_acks(<<_:6, QoS:2, Rest/binary>>, Acks)
+  when is_integer(QoS) and ((QoS >= 0) and (QoS =< 2)) ->
+    parse_acks(Rest, [QoS | Acks]).
+
+-spec serialise(mqtt_frame()) -> binary() | iolist().
+serialise(#mqtt_publish{qos=0,
+                        topic=Topic,
+                        retain=Retain,
+                        dup=Dup,
+                        payload=Payload}) ->
+    Var = [utf8(vmq_topic:unword(Topic)), Payload],
+    LenBytes = serialise_len(iolist_size(Var)),
+    [<<?PUBLISH:4, (flag(Dup)):1/integer, 0:2/integer, (flag(Retain)):1/integer>>, LenBytes, Var];
+serialise(#mqtt_publish{message_id=MessageId,
+                        topic=Topic,
+                        qos=QoS,
+                        retain=Retain,
+                        dup=Dup,
+                        payload=Payload}) ->
+    Var = [utf8(vmq_topic:unword(Topic)), msg_id(MessageId), Payload],
+    LenBytes = serialise_len(iolist_size(Var)),
+    [<<?PUBLISH:4, (flag(Dup)):1/integer,
+       (default(QoS, 0)):2/integer, (flag(Retain)):1/integer>>, LenBytes, Var];
+
+serialise(#mqtt_puback{message_id=MessageId}) ->
+    <<?PUBACK:4, 0:4, 2, MessageId:16/big>>;
+serialise(#mqtt_pubrel{message_id=MessageId}) ->
+    <<?PUBREL:4, 0:2, 1:1, 0:1, 2, MessageId:16/big>>;
+serialise(#mqtt_pubrec{message_id=MessageId}) ->
+    <<?PUBREC:4, 0:4, 2, MessageId:16/big>>;
+serialise(#mqtt_pubcomp{message_id=MessageId}) ->
+    <<?PUBCOMP:4, 0:4, 2, MessageId:16/big>>;
+serialise(#mqtt_connect{proto_ver=ProtoVersion,
+                        username=UserName,
+                        password=Password,
+                        will_retain=WillRetain,
+                        will_qos=WillQos,
+                        clean_session=CleanSession,
+                        keep_alive=KeepAlive,
+                        client_id=ClientId,
+                        will_topic=WillTopic,
+                        will_msg=WillMsg}) ->
+    {PMagicL, PMagic} = proto(ProtoVersion),
+    Var = [<<PMagicL:16/big-unsigned-integer, PMagic/binary,
+             ProtoVersion:8/unsigned-integer,
+             (flag(UserName)):1/integer,
+             (flag(Password)):1/integer,
+             (flag(WillRetain)):1/integer,
+             (default(WillQos, 0)):2/integer,
+             (flag(WillTopic)):1/integer,
+             (flag(CleanSession)):1/integer,
+             0:1,  % reserved
+             (default(KeepAlive, 0)):16/big-unsigned-integer>>,
+           utf8(ClientId),
+           utf8(vmq_topic:unword(WillTopic)),
+           utf8(WillMsg),
+           utf8(UserName),
+           utf8(Password)],
+    LenBytes = serialise_len(iolist_size(Var)),
+    [<<?CONNECT:4, 0:4>>, LenBytes, Var];
+serialise(#mqtt_connack{session_present=SP, return_code=RC}) ->
+    [<<?CONNACK:4, 0:4>>, serialise_len(2), <<0:7, (flag(SP)):1/integer>>, <<RC:8/big>>];
+serialise(#mqtt_subscribe{message_id=MessageId, topics=Topics}) ->
+    SerialisedTopics = serialise_topics(?SUBSCRIBE, Topics, []),
+    LenBytes = serialise_len(iolist_size(SerialisedTopics) + 2),
+    [<<?SUBSCRIBE:4, 0:2, 1:1, 0:1>>, LenBytes, <<MessageId:16/big>>, SerialisedTopics];
+serialise(#mqtt_suback{message_id=MessageId, qos_table=QosTable}) ->
+    SerialisedAcks = serialise_acks(QosTable, []),
+    LenBytes = serialise_len(iolist_size(SerialisedAcks) + 2),
+    [<<?SUBACK:4, 0:4>>, LenBytes, <<MessageId:16/big>>, SerialisedAcks];
+serialise(#mqtt_unsubscribe{message_id=MessageId, topics=Topics}) ->
+    SerialisedTopics = serialise_topics(?UNSUBSCRIBE, Topics, []),
+    LenBytes = serialise_len(iolist_size(SerialisedTopics) + 2),
+    [<<?UNSUBSCRIBE:4, 0:2, 1:1, 0:1>>, LenBytes, <<MessageId:16/big>>,
+     SerialisedTopics];
+serialise(#mqtt_unsuback{message_id=MessageId}) ->
+    <<?UNSUBACK:4, 0:4, 2, MessageId:16/big>>;
+serialise(#mqtt_pingreq{}) ->
+    <<?PINGREQ:4, 0:4, 0>>;
+serialise(#mqtt_pingresp{}) ->
+    <<?PINGRESP:4, 0:4, 0>>;
+serialise(#mqtt_disconnect{}) ->
+    <<?DISCONNECT:4, 0:4, 0>>.
+
+serialise_len(N) when N =< ?LOWBITS ->
+    <<0:1, N:7>>;
+serialise_len(N) ->
+    <<1:1, (N rem ?HIGHBIT):7, (serialise_len(N div ?HIGHBIT))/binary>>.
+
+serialise_topics(?SUBSCRIBE = Sub, [{Topic, QoS}|Rest], Acc) ->
+    serialise_topics(Sub, Rest, [utf8(vmq_topic:unword(Topic)), <<0:6, QoS:2>>|Acc]);
+serialise_topics(?UNSUBSCRIBE = Sub, [Topic|Rest], Acc) ->
+    serialise_topics(Sub, Rest, [utf8(vmq_topic:unword(Topic))|Acc]);
+serialise_topics(_, [], Topics) ->
+    Topics.
+
+serialise_acks([QoS|Rest], Acks) when is_integer(QoS) and ((QoS >= 0) and (QoS =< 2)) ->
+    serialise_acks(Rest, [<<0:6, QoS:2>>|Acks]);
+serialise_acks([_|Rest], Acks) ->
+    %% use 0x80 failure code for everything else
+    serialise_acks(Rest, [<<128:8>>|Acks]);
+serialise_acks([], Acks) ->
+    Acks.
+
+proto(4) -> {4, ?PROTOCOL_MAGIC_311};
+proto(3) -> {6, ?PROTOCOL_MAGIC_31};
+proto(131) -> {6, ?PROTOCOL_MAGIC_31};
+proto(132) -> {4, ?PROTOCOL_MAGIC_311}.
+
+flag(<<>>) -> 0;
+flag(undefined) -> 0;
+flag(0) -> 0;
+flag(1) -> 1;
+flag(false) -> 0;
+flag(true) -> 1;
+flag(V) when is_binary(V) orelse is_list(V) -> 1;
+flag(empty) -> 1; %% for test purposes
+flag(_) -> 0.
+
+msg_id(undefined) -> <<>>;
+msg_id(MsgId) -> <<MsgId:16/big>>.
+
+default(undefined, Default) -> Default;
+default(Val, _) -> Val.
+
+utf8(<<>>) -> <<>>;
+utf8(undefined) -> <<>>;
+utf8(empty) -> <<0:16/big>>; %% for test purposes, useful if you want to encode an empty string..
+utf8(IoList) when is_list(IoList) ->
+    [<<(iolist_size(IoList)):16/big>>, IoList];
+utf8(Bin) when is_binary(Bin) ->
+    <<(byte_size(Bin)):16/big, Bin/binary>>.
+
+ensure_binary(L) when is_list(L) -> list_to_binary(L);
+ensure_binary(B) when is_binary(B) -> B;
+ensure_binary(undefined) -> undefined;
+ensure_binary(empty) -> empty. % for test purposes
+%%%%%%% packet generator functions (useful for testing)
+gen_connect(ClientId, Opts) ->
+    Frame = #mqtt_connect{
+              client_id = ensure_binary(ClientId),
+              clean_session =  proplists:get_value(clean_session, Opts, true),
+              keep_alive =     proplists:get_value(keepalive, Opts, 60),
+              username =       ensure_binary(proplists:get_value(username, Opts)),
+              password =       ensure_binary(proplists:get_value(password, Opts)),
+              proto_ver =      proplists:get_value(proto_ver, Opts, 3),
+              will_topic =     ensure_binary(proplists:get_value(will_topic, Opts)),
+              will_qos =       proplists:get_value(will_qos, Opts, 0),
+              will_retain =    proplists:get_value(will_retain, Opts, false),
+              will_msg =       ensure_binary(proplists:get_value(will_msg, Opts))
+              },
+    iolist_to_binary(serialise(Frame)).
+
+gen_connack() ->
+    gen_connack(?CONNACK_ACCEPT).
+gen_connack(RC) ->
+    gen_connack(0, RC).
+gen_connack(SP, RC) ->
+    iolist_to_binary(serialise(#mqtt_connack{session_present=flag(SP), return_code=RC})).
+
+gen_publish(Topic, Qos, Payload, Opts) ->
+    Frame = #mqtt_publish{
+               dup =               proplists:get_value(dup, Opts, false),
+               qos =               Qos,
+               retain =            proplists:get_value(retain, Opts, false),
+               topic =             ensure_binary(Topic),
+               message_id =        proplists:get_value(mid, Opts, 0),
+               payload =           ensure_binary(Payload)
+              },
+    iolist_to_binary(serialise(Frame)).
+
+gen_puback(MId) ->
+    iolist_to_binary(serialise(#mqtt_puback{message_id=MId})).
+
+gen_pubrec(MId) ->
+    iolist_to_binary(serialise(#mqtt_pubrec{message_id=MId})).
+
+gen_pubrel(MId) ->
+    iolist_to_binary(serialise(#mqtt_pubrel{message_id=MId})).
+
+gen_pubcomp(MId) ->
+    iolist_to_binary(serialise(#mqtt_pubcomp{message_id=MId})).
+
+gen_subscribe(MId, [{_, _}|_] = Topics) ->
+    BinTopics = [{ensure_binary(Topic), QoS} || {Topic, QoS} <- Topics],
+    iolist_to_binary(serialise(#mqtt_subscribe{topics=BinTopics, message_id=MId})).
+gen_subscribe(MId, Topic, QoS) ->
+    gen_subscribe(MId, [{Topic, QoS}]).
+
+gen_suback(MId, QoSs) when is_list(QoSs) ->
+    iolist_to_binary(serialise(#mqtt_suback{qos_table=QoSs, message_id=MId}));
+gen_suback(MId, QoS) ->
+    gen_suback(MId, [QoS]).
+
+gen_unsubscribe(MId, Topic) ->
+    iolist_to_binary(serialise(#mqtt_unsubscribe{topics=[ensure_binary(Topic)], message_id=MId})).
+
+gen_unsuback(MId) ->
+    iolist_to_binary(serialise(#mqtt_unsuback{message_id=MId})).
+
+gen_pingreq() ->
+    iolist_to_binary(serialise(#mqtt_pingreq{})).
+
+gen_pingresp() ->
+    iolist_to_binary(serialise(#mqtt_pingresp{})).
+
+gen_disconnect() ->
+    iolist_to_binary(serialise(#mqtt_disconnect{})).

--- a/src/vmq_topic.erl
+++ b/src/vmq_topic.erl
@@ -1,0 +1,244 @@
+%% Copyright 2019 Octavo Labs AG Zurich Switzerland (https://octavolabs.com)
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+-module(vmq_topic).
+
+-import(lists, [reverse/1]).
+
+%% ------------------------------------------------------------------------
+%% Topic semantics and usage
+%% ------------------------------------------------------------------------
+%% A topic must be at least one character long.
+%%
+%% Topic names are case sensitive. For example, ACCOUNTS and Accounts are two different topics.
+%%
+%% Topic names can include the space character. For example, Accounts payable is a valid topic.
+%%
+%% A leading "/" creates a distinct topic. For example, /finance is different from finance. /finance matches "+/+" and "/+", but not "+".
+%%
+%% Do not include the null character (Unicode \x0000) in any topic.
+%%
+%% The following principles apply to the construction and content of a topic tree:
+%%
+%% The length is limited to 64k but within that there are no limits to the number of levels in a topic tree.
+%%
+%% There can be any number of root nodes; that is, there can be any number of topic trees.
+%% ------------------------------------------------------------------------
+
+-export([new/1,
+         match/2,
+         validate_topic/2,
+         contains_wildcard/1,
+         unword/1,
+         word/1,
+         triples/1]).
+
+-define(MAX_LEN, 65536).
+
+new(Name) when is_list(Name) ->
+    {topic, Name}.
+
+%% ------------------------------------------------------------------------
+%% topic match
+%% ------------------------------------------------------------------------
+match([], []) ->
+	true;
+match([H|T1], [H|T2]) ->
+	match(T1, T2);
+match([_H|T1], [<<"+">>|T2]) ->
+	match(T1, T2);
+match(_, [<<"#">>]) ->
+	true;
+match([_H1|_], [_H2|_]) ->
+	false;
+match([], [_H|_T2]) ->
+	false;
+match(_, _) -> false.
+
+
+%% ------------------------------------------------------------------------
+%% topic validate
+%% ------------------------------------------------------------------------
+triples([Word|_] = Topic) when is_binary(Word) ->
+    triples(reverse(Topic), []).
+
+triples([Word], Acc) ->
+    [{root, Word, [Word]}|Acc];
+triples([Word|Rest] = Topic, Acc) ->
+    triples(Rest, [{reverse(Rest), Word, reverse(Topic)}|Acc]).
+
+unword(Topic) ->
+    vernemq_dev_api:unword_topic(Topic).
+
+word(Topic) ->
+    re:split(Topic, <<"/">>).
+
+validate_topic(_Type, <<>>) ->
+    {error, no_empty_topic_allowed};
+validate_topic(_Type, Topic) when byte_size(Topic) > ?MAX_LEN ->
+    {error, subscribe_topic_too_long};
+validate_topic(publish, Topic) ->
+    validate_publish_topic(Topic, 0, []);
+validate_topic(subscribe, Topic) ->
+    validate_subscribe_topic(Topic, 0, []).
+
+contains_wildcard([<<"+">>|_]) -> true;
+contains_wildcard([<<"#">>]) -> true;
+contains_wildcard([_|Rest]) ->
+    contains_wildcard(Rest);
+contains_wildcard([]) -> false.
+
+validate_publish_topic(<<"+/", _/binary>>, _, _) -> {error, 'no_+_allowed_in_publish'};
+validate_publish_topic(<<"+">>, _, _) -> {error, 'no_+_allowed_in_publish'};
+validate_publish_topic(<<"#">>,_, _) -> {error, 'no_#_allowed_in_publish'};
+validate_publish_topic(Topic, L, Acc) ->
+    case Topic of
+        <<Word:L/binary, "/", Rest/binary>> ->
+            validate_publish_topic(Rest, 0, [Word|Acc]);
+        <<Word:L/binary>> ->
+            {ok, lists:reverse([Word|Acc])};
+        <<_:L/binary, "+", _/binary>> ->
+            {error, 'no_+_allowed_in_word'};
+        <<_:L/binary, "#", _/binary>> ->
+            {error, 'no_#_allowed_in_word'};
+        _ ->
+            validate_publish_topic(Topic, L + 1, Acc)
+    end.
+
+validate_subscribe_topic(<<"+/", Rest/binary>>, _, Acc) -> validate_subscribe_topic(Rest, 0, [<<"+">>|Acc]);
+validate_subscribe_topic(<<"+">>, _, Acc) -> validate_shared_subscription(reverse([<<"+">>|Acc]));
+validate_subscribe_topic(<<"#">>, _, Acc) -> validate_shared_subscription(reverse([<<"#">>|Acc]));
+validate_subscribe_topic(Topic, L, Acc) ->
+    case Topic of
+        <<Word:L/binary, "/", Rest/binary>> ->
+            validate_subscribe_topic(Rest, 0, [Word|Acc]);
+        <<Word:L/binary>> ->
+            validate_shared_subscription(reverse([Word|Acc]));
+        <<_:L/binary, "+", _/binary>> ->
+            {error, 'no_+_allowed_in_word'};
+        <<_:L/binary, "#", _/binary>> ->
+            {error, 'no_#_allowed_in_word'};
+        _ ->
+            validate_subscribe_topic(Topic, L + 1, Acc)
+    end.
+
+validate_shared_subscription([<<"$share">>, _Group, _FirstWord | _] = Topic) -> {ok, Topic};
+validate_shared_subscription([<<"$share">> | _] = _Topic) -> {error, invalid_shared_subscription};
+validate_shared_subscription(Topic) -> {ok, Topic}.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+validate_no_wildcard_test() ->
+    % no wildcard
+    {ok, [<<"a">>, <<"b">>, <<"c">>]}
+    = validate_topic(subscribe, <<"a/b/c">>),
+    {ok, [<<>>, <<"a">>, <<"b">>]}
+    = validate_topic(subscribe, <<"/a/b">>),
+    {ok, [<<"test">>, <<"topic">>, <<>>]}
+    = validate_topic(subscribe, <<"test/topic/">>),
+    {ok, [<<"test">>, <<>>, <<>>, <<>>, <<"a">>, <<>>, <<"topic">>]}
+    = validate_topic(subscribe, <<"test////a//topic">>),
+    {ok, [<<>>, <<"test">>, <<>>, <<>>, <<>>, <<"a">>, <<>>, <<"topic">>]}
+    = validate_topic(subscribe, <<"/test////a//topic">>),
+
+    {ok, [<<"foo">>, <<>>, <<"bar">>, <<>>, <<>>, <<"baz">>]}
+    = validate_topic(publish, <<"foo//bar///baz">>),
+    {ok, [<<"foo">>, <<>>, <<"baz">>, <<>>, <<>>]}
+    = validate_topic(publish, <<"foo//baz//">>),
+    {ok, [<<"foo">>, <<>>, <<"baz">>]}
+    = validate_topic(publish, <<"foo//baz">>),
+    {ok, [<<"foo">>, <<>>, <<"baz">>, <<"bar">>]}
+    = validate_topic(publish, <<"foo//baz/bar">>),
+    {ok, [<<>>, <<>>, <<>>, <<>>, <<"foo">>, <<>>, <<>>, <<"bar">>]}
+    = validate_topic(publish, <<"////foo///bar">>).
+
+validate_wildcard_test() ->
+    {ok, [<<>>, <<"+">>, <<"x">>]}
+    = validate_topic(subscribe, <<"/+/x">>),
+    {ok, [<<>>, <<"a">>, <<"b">>, <<"c">>, <<"#">>]}
+    = validate_topic(subscribe, <<"/a/b/c/#">>),
+    {ok, [<<"#">>]}
+    = validate_topic(subscribe, <<"#">>),
+    {ok, [<<"foo">>, <<"#">>]}
+    = validate_topic(subscribe, <<"foo/#">>),
+    {ok, [<<"foo">>, <<"+">>, <<"baz">>]}
+    = validate_topic(subscribe, <<"foo/+/baz">>),
+    {ok, [<<"foo">>, <<"+">>, <<"baz">>, <<"#">>]}
+    = validate_topic(subscribe, <<"foo/+/baz/#">>),
+    {ok, [<<"foo">>, <<"foo">>, <<"baz">>, <<"#">>]}
+    = validate_topic(subscribe, <<"foo/foo/baz/#">>),
+    {ok, [<<"foo">>, <<"#">>]} = validate_topic(subscribe, <<"foo/#">>),
+    {ok, [<<>>, <<"#">>]} = validate_topic(subscribe, <<"/#">>),
+    {ok, [<<"test">>, <<"topic">>, <<"+">>]} = validate_topic(subscribe, <<"test/topic/+">>),
+    {ok, [<<"+">>, <<"+">>, <<"+">>, <<"+">>, <<"+">>,
+          <<"+">>, <<"+">>, <<"+">>, <<"+">>, <<"+">>, <<"test">>]}
+    = validate_topic(subscribe, <<"+/+/+/+/+/+/+/+/+/+/test">>),
+
+    {error, 'no_#_allowed_in_word'} = validate_topic(publish, <<"test/#-">>),
+    {error, 'no_+_allowed_in_word'} = validate_topic(publish, <<"test/+-">>),
+    {error, 'no_+_allowed_in_publish'} = validate_topic(publish, <<"test/+/">>),
+    {error, 'no_#_allowed_in_publish'} = validate_topic(publish, <<"test/#">>),
+
+	{error, 'no_#_allowed_in_word'} = validate_topic(subscribe, <<"a/#/c">>),
+    {error, 'no_#_allowed_in_word'} = validate_topic(subscribe, <<"#testtopic">>),
+    {error, 'no_#_allowed_in_word'} = validate_topic(subscribe, <<"testtopic#">>),
+    {error, 'no_+_allowed_in_word'} = validate_topic(subscribe, <<"+testtopic">>),
+    {error, 'no_+_allowed_in_word'} = validate_topic(subscribe, <<"testtopic+">>),
+    {error, 'no_#_allowed_in_word'} = validate_topic(subscribe, <<"#testtopic/test">>),
+    {error, 'no_#_allowed_in_word'} = validate_topic(subscribe, <<"testtopic#/test">>),
+    {error, 'no_+_allowed_in_word'} = validate_topic(subscribe, <<"+testtopic/test">>),
+    {error, 'no_+_allowed_in_word'} = validate_topic(subscribe, <<"testtopic+/test">>),
+    {error, 'no_#_allowed_in_word'} = validate_topic(subscribe, <<"/test/#testtopic">>),
+    {error, 'no_#_allowed_in_word'} = validate_topic(subscribe, <<"/test/testtopic#">>),
+    {error, 'no_+_allowed_in_word'} = validate_topic(subscribe, <<"/test/+testtopic">>),
+    {error, 'no_+_allowed_in_word'} = validate_topic(subscribe, <<"/testtesttopic+">>).
+
+validate_shared_subscription_test() ->
+    {error, invalid_shared_subscription} = validate_topic(subscribe, <<"$share/mygroup">>),
+    {ok, [<<"$share">>, <<"mygroup">>, <<"a">>, <<"b">>]} = validate_topic(subscribe, <<"$share/mygroup/a/b">>).
+
+validate_unword_test() ->
+    rand:seed(exsplus, erlang:timestamp()),
+    random_topics(1000),
+    ok.
+
+contains_wildcard_test() ->
+    true = contains_wildcard([<<"a">>, <<"+">>, <<"b">>]),
+    true = contains_wildcard([<<"#">>]),
+    false = contains_wildcard([<<"a">>, <<"b">>, <<"c">>]).
+
+random_topics(0) -> ok;
+random_topics(N) when N > 0 ->
+    NWords = rand:uniform(100),
+    Words =
+    lists:foldl(fun(_, AAcc) ->
+                    case rand:uniform(3) of
+                        1 ->
+                            ["+/"|AAcc];
+                        _ ->
+                            [random_word(), "/"|AAcc]
+                    end
+                end, [], lists:seq(1, NWords)),
+    Topic = iolist_to_binary(Words),
+    {ok, T} = validate_topic(subscribe, Topic),
+    Topic = iolist_to_binary(unword(T)),
+    random_topics(N - 1).
+
+random_word() ->
+    Words = "abcdefghijklmnopqrstuvwxyz0123456789",
+    N = rand:uniform(length(Words)),
+    S = rand:uniform(length(Words) + 1 - N),
+    string:substr(Words, N, S).
+
+-endif.

--- a/src/vmq_types.hrl
+++ b/src/vmq_types.hrl
@@ -1,0 +1,5 @@
+-ifndef(VERNEMQ_TYPES_HRL).
+-define(VERNEMQ_TYPES_HRL, true).
+-include_lib("vmq_types_mqtt.hrl").
+-include_lib("vmq_types_mqtt5.hrl").
+-endif.

--- a/src/vmq_types_common.hrl
+++ b/src/vmq_types_common.hrl
@@ -1,0 +1,29 @@
+-ifndef(VMQ_TYPE_COMMON_HRL).
+-define(VMQ_TYPE_COMMON_HRL, true).
+-include_lib("vernemq_dev/include/vernemq_dev.hrl").
+
+-type msg_id()          :: undefined | 0..65535.
+
+-type routing_key()         :: [binary()].
+-type msg_ref()             :: binary().
+
+-type msg_expiry_ts() :: {expire_after, non_neg_integer()}
+                       | {non_neg_integer(), non_neg_integer()}.
+
+-record(vmq_msg, {
+          msg_ref               :: msg_ref() | 'undefined', % OTP-12719
+          routing_key           :: routing_key() | 'undefined',
+          payload               :: payload() | 'undefined',
+          retain=false          :: flag(),
+          dup=false             :: flag(),
+          qos                   :: qos(),
+          mountpoint            :: mountpoint(),
+          persisted=false       :: flag(),
+          sg_policy=prefer_local:: shared_sub_policy(),
+          %% TODOv5: need to import the mqtt5 property typespec?
+          properties=#{}        :: map(),
+          expiry_ts             :: undefined
+                                 | msg_expiry_ts()
+         }).
+-type msg()             :: #vmq_msg{}.
+-endif.

--- a/src/vmq_types_mqtt.hrl
+++ b/src/vmq_types_mqtt.hrl
@@ -1,0 +1,114 @@
+-include_lib("vernemq_dev/include/vernemq_dev.hrl").
+-include("vmq_types_common.hrl").
+
+%% connect return codes
+-define(CONNACK_ACCEPT,      0).
+-define(CONNACK_PROTO_VER,   1). %% unacceptable protocol version
+-define(CONNACK_INVALID_ID,  2). %% identifier rejected
+-define(CONNACK_SERVER,      3). %% server unavailable
+-define(CONNACK_CREDENTIALS, 4). %% bad user name or password
+-define(CONNACK_AUTH,        5). %% not authorized
+
+-type proto_version()       :: 3 | 4 | 131 | 132.
+-type return_code()         :: ?CONNACK_ACCEPT
+                            | ?CONNACK_PROTO_VER
+                            | ?CONNACK_INVALID_ID
+                            | ?CONNACK_SERVER
+                            | ?CONNACK_CREDENTIALS
+                            | ?CONNACK_AUTH.
+-record(mqtt_connect, {
+          proto_ver         :: proto_version(),
+          username          :: username(),
+          password          :: password(),
+          clean_session     :: flag(),
+          keep_alive        :: non_neg_integer(),
+          client_id         :: client_id(),
+          will_retain       :: flag() | undefined,
+          will_qos          :: qos() | undefined,
+          will_topic        :: topic() | undefined,
+          will_msg          :: payload() | undefined
+         }).
+-type mqtt_connect()        :: #mqtt_connect{}.
+
+-record(mqtt_connack, {
+          session_present   :: flag(),
+          return_code       :: return_code()
+         }).
+-type mqtt_connack()        :: #mqtt_connack{}.
+
+-record(mqtt_publish, {
+          message_id        :: msg_id(),
+          topic             :: topic(),
+          qos               :: qos(),
+          retain            :: flag(),
+          dup               :: flag(),
+          payload           :: payload()
+        }).
+-type mqtt_publish()        :: #mqtt_publish{}.
+
+-record(mqtt_puback, {
+          message_id        :: msg_id()
+         }).
+-type mqtt_puback()        :: #mqtt_puback{}.
+
+-record(mqtt_pubrec, {
+          message_id        :: msg_id()
+         }).
+-type mqtt_pubrec()        :: #mqtt_pubrec{}.
+
+-record(mqtt_pubrel, {
+          message_id        :: msg_id()
+         }).
+-type mqtt_pubrel()        :: #mqtt_pubrel{}.
+
+-record(mqtt_pubcomp, {
+          message_id        :: msg_id()
+         }).
+-type mqtt_pubcomp()        :: #mqtt_pubcomp{}.
+
+-record(mqtt_subscribe, {
+          message_id        :: msg_id(),
+          topics=[]         :: [{topic(), qos()}]
+         }).
+-type mqtt_subscribe()      :: #mqtt_subscribe{}.
+
+-record(mqtt_unsubscribe, {
+          message_id        :: msg_id(),
+          topics=[]         :: [topic()]
+         }).
+-type mqtt_unsubscribe()    :: #mqtt_unsubscribe{}.
+
+-record(mqtt_suback, {
+          message_id        :: msg_id(),
+          qos_table=[]      :: [qos()]
+         }).
+-type mqtt_suback()         :: #mqtt_suback{}.
+
+-record(mqtt_unsuback, {
+          message_id        :: msg_id()
+         }).
+-type mqtt_unsuback()       :: #mqtt_unsuback{}.
+
+-record(mqtt_pingreq, {}).
+-type mqtt_pingreq()        :: #mqtt_pingreq{}.
+
+-record(mqtt_pingresp, {}).
+-type mqtt_pingresp()       :: #mqtt_pingresp{}.
+
+-record(mqtt_disconnect, {}).
+-type mqtt_disconnect()     :: #mqtt_disconnect{}.
+
+-type mqtt_frame()          :: mqtt_connect()
+                             | mqtt_connack()
+                             | mqtt_publish()
+                             | mqtt_puback()
+                             | mqtt_pubrec()
+                             | mqtt_pubrel()
+                             | mqtt_pubcomp()
+                             | mqtt_subscribe()
+                             | mqtt_suback()
+                             | mqtt_unsubscribe()
+                             | mqtt_unsuback()
+                             | mqtt_pingreq()
+                             | mqtt_pingresp()
+                             | mqtt_disconnect().

--- a/src/vmq_types_mqtt5.hrl
+++ b/src/vmq_types_mqtt5.hrl
@@ -1,0 +1,430 @@
+-include_lib("vernemq_dev/include/vernemq_dev.hrl").
+-include("vmq_types_common.hrl").
+
+%% Reason codes
+-define(M5_SUCCESS,                        16#00).
+-define(M5_NORMAL_DISCONNECT,              16#00).
+-define(M5_CONNACK_ACCEPT,                 16#00).
+-define(M5_GRANTED_QOS0,                   16#00).
+-define(M5_GRANTED_QOS1,                   16#01).
+-define(M5_GRANTED_QOS2,                   16#02).
+-define(M5_DISCONNECT_WITH_WILL_MSG,       16#04).
+-define(M5_NO_MATCHING_SUBSCRIBERS,        16#10).
+-define(M5_NO_SUBSCRIPTION_EXISTED,        16#11).
+-define(M5_CONTINUE_AUTHENTICATION,        16#18).
+-define(M5_REAUTHENTICATE,                 16#19).
+-define(M5_UNSPECIFIED_ERROR,              16#80).
+-define(M5_MALFORMED_PACKET,               16#81).
+-define(M5_PROTOCOL_ERROR,                 16#82).
+-define(M5_IMPL_SPECIFIC_ERROR,            16#83).
+-define(M5_UNSUPPORTED_PROTOCOL_VERSION,   16#84).
+-define(M5_CLIENT_IDENTIFIER_NOT_VALID,    16#85).
+-define(M5_BAD_USERNAME_OR_PASSWORD,       16#86).
+-define(M5_NOT_AUTHORIZED,                 16#87).
+-define(M5_SERVER_UNAVAILABLE,             16#88).
+-define(M5_SERVER_BUSY,                    16#89).
+-define(M5_BANNED,                         16#8A).
+-define(M5_SERVER_SHUTTING_DOWN,           16#8B).
+-define(M5_BAD_AUTHENTICATION_METHOD,      16#8C).
+-define(M5_KEEP_ALIVE_TIMEOUT,             16#8D).
+-define(M5_SESSION_TAKEN_OVER,             16#8E).
+-define(M5_TOPIC_FILTER_INVALID,           16#8F).
+-define(M5_TOPIC_NAME_INVALID,             16#90).
+-define(M5_PACKET_ID_IN_USE,               16#91).
+-define(M5_PACKET_ID_NOT_FOUND,            16#92).
+-define(M5_RECEIVE_MAX_EXCEEDED,           16#93).
+-define(M5_TOPIC_ALIAS_INVALID,            16#94).
+-define(M5_PACKET_TOO_LARGE,               16#95).
+-define(M5_MESSAGE_RATE_TOO_HIGH,          16#96).
+-define(M5_QUOTA_EXCEEDED,                 16#97).
+-define(M5_ADMINISTRATIVE_ACTION,          16#98).
+-define(M5_PAYLOAD_FORMAT_INVALID,         16#99).
+-define(M5_RETAIN_NOT_SUPPORTED,           16#9A).
+-define(M5_QOS_NOT_SUPPORTED,              16#9B).
+-define(M5_USE_ANOTHER_SERVER,             16#9C).
+-define(M5_SERVER_MOVED,                   16#9D).
+-define(M5_SHARED_SUBS_NOT_SUPPORTED,      16#9E).
+-define(M5_CONNECTION_RATE_EXCEEDED,       16#9F).
+-define(M5_MAX_CONNECT_TIME,               16#A0).
+-define(M5_SUBSCRIPTION_IDS_NOT_SUPPORTED, 16#A1).
+-define(M5_WILDCARD_SUBS_NOT_SUPPORTED,    16#A2).
+
+
+-type mqtt5_properties() :: map().
+
+-record(mqtt5_lwt, {
+          will_properties=#{} :: mqtt5_properties(),
+          will_retain       :: flag(),
+          will_qos          :: qos(),
+          will_topic        :: topic(),
+          will_msg          :: payload()
+         }).
+
+-type mqtt5_lwt() :: #mqtt5_lwt{}.
+
+
+-define(P_PAYLOAD_FORMAT_INDICATOR_ASSOC, p_payload_format_indicator => unspecified | utf8).
+-define(P_MESSAGE_EXPIRY_INTERVAL_ASSOC, p_message_expiry_interval => seconds()).
+-define(P_CONTENT_TYPE_ASSOC, p_content_type => utf8string()).
+-define(P_RESPONSE_TOPIC_ASSOC, p_response_topic => topic()).
+-define(P_CORRELATION_DATA_ASSOC, p_correlation_data => binary()).
+-define(P_SUBSCRIPTION_ID_ASSOC, p_subscription_id => [subscription_id()]).
+-define(P_SESSION_EXPIRY_INTERVAL_ASSOC, p_session_expiry_interval => seconds()).
+-define(P_ASSIGNED_CLIENT_ID_ASSOC, p_assigned_client_id => utf8string()).
+-define(P_SERVER_KEEP_ALIVE_ASSOC, p_server_keep_alive => seconds()).
+-define(P_AUTHENTICATION_METHOD_ASSOC, p_authentication_method => utf8string()).
+-define(P_AUTHENTICATION_DATA_ASSOC, p_authentication_data => binary()).
+-define(P_REQUEST_PROBLEM_INFO_ASSOC, p_request_problem_info => boolean()).
+-define(P_WILL_DELAY_INTERVAL_ASSOC, p_will_delay_interval => seconds()).
+-define(P_REQUEST_RESPONSE_INFO_ASSOC, p_request_response_info => boolean()).
+-define(P_RESPONSE_INFO_ASSOC, p_response_info => utf8string()).
+-define(P_SERVER_REF_ASSOC, p_server_ref => utf8string()).
+-define(P_REASON_STRING_ASSOC, p_reason_string => utf8string()).
+-define(P_RECEIVE_MAX_ASSOC, p_receive_max => 1..65535).
+-define(P_TOPIC_ALIAS_MAX_ASSOC, p_topic_alias_max => 1..65535).
+-define(P_TOPIC_ALIAS_ASSOC, p_topic_alias => 1..65535).
+-define(P_MAX_QOS_ASSOC, p_max_qos => 0|1).
+-define(P_RETAIN_AVAILABLE_ASSOC, p_retain_available => boolean()).
+-define(P_USER_PROPERTY_ASSOC, p_user_property => [user_property()]).
+-define(P_MAX_PACKET_SIZE_ASSOC, p_max_packet_size => 1..4294967296).
+-define(P_WILDCARD_SUBS_AVAILABLE_ASSOC, p_wildcard_subs_available => boolean()).
+-define(P_SUB_IDS_AVAILABLE_ASSOC, p_sub_ids_available => boolean()).
+-define(P_SHARED_SUBS_AVAILABLE_ASSOC, p_shared_subs_available => boolean()).
+
+-record(mqtt5_connect, {
+          proto_ver         :: 5,
+          username          :: username(),
+          password          :: password(),
+          clean_start       :: flag(),
+          keep_alive        :: non_neg_integer(),
+          client_id         :: client_id(),
+          lwt               :: mqtt5_lwt() | undefined,
+          properties=#{}    :: mqtt5_properties()
+         }).
+-type mqtt5_connect()        :: #mqtt5_connect{}.
+-type mqtt5_connect_props() :: #{?P_SESSION_EXPIRY_INTERVAL_ASSOC,
+                                 ?P_AUTHENTICATION_METHOD_ASSOC,
+                                 ?P_AUTHENTICATION_DATA_ASSOC,
+                                 ?P_REQUEST_PROBLEM_INFO_ASSOC,
+                                 ?P_RECEIVE_MAX_ASSOC,
+                                 ?P_TOPIC_ALIAS_MAX_ASSOC,
+                                 ?P_USER_PROPERTY_ASSOC,
+                                 ?P_MAX_PACKET_SIZE_ASSOC}.
+-type mqtt5_will_property() :: #{?P_WILL_DELAY_INTERVAL_ASSOC,
+                                 ?P_PAYLOAD_FORMAT_INDICATOR_ASSOC,
+                                 ?P_MESSAGE_EXPIRY_INTERVAL_ASSOC,
+                                 ?P_CONTENT_TYPE_ASSOC,
+                                 ?P_RESPONSE_TOPIC_ASSOC,
+                                 ?P_CORRELATION_DATA_ASSOC,
+                                 ?P_USER_PROPERTY_ASSOC}.
+
+-record(mqtt5_connack, {
+          session_present   :: flag(),
+          reason_code       :: reason_code(),
+          properties=#{}    :: mqtt5_connack_props()
+         }).
+-type mqtt5_connack()       :: #mqtt5_connack{}.
+-type mqtt5_connack_props() :: #{?P_SESSION_EXPIRY_INTERVAL_ASSOC,
+                                 ?P_ASSIGNED_CLIENT_ID_ASSOC,
+                                 ?P_SERVER_KEEP_ALIVE_ASSOC,
+                                 ?P_AUTHENTICATION_DATA_ASSOC,
+                                 ?P_AUTHENTICATION_METHOD_ASSOC,
+                                 ?P_RESPONSE_INFO_ASSOC,
+                                 ?P_SERVER_REF_ASSOC,
+                                 ?P_REASON_STRING_ASSOC,
+                                 ?P_RECEIVE_MAX_ASSOC,
+                                 ?P_TOPIC_ALIAS_MAX_ASSOC,
+                                 ?P_MAX_QOS_ASSOC,
+                                 ?P_MAX_PACKET_SIZE_ASSOC,
+                                 ?P_WILDCARD_SUBS_AVAILABLE_ASSOC,
+                                 ?P_SUB_IDS_AVAILABLE_ASSOC,
+                                 ?P_SHARED_SUBS_AVAILABLE_ASSOC}.
+
+-record(mqtt5_publish, {
+          message_id        :: msg_id(),
+          topic             :: topic(),
+          qos               :: qos(),
+          retain            :: flag(),
+          dup               :: flag(),
+          properties=#{}    :: mqtt5_publish_props(),
+          payload           :: payload()
+        }).
+-type mqtt5_publish()       :: #mqtt5_publish{}.
+-type mqtt5_publish_props() :: #{?P_PAYLOAD_FORMAT_INDICATOR_ASSOC,
+                                 ?P_MESSAGE_EXPIRY_INTERVAL_ASSOC,
+                                 ?P_CONTENT_TYPE_ASSOC,
+                                 ?P_RESPONSE_TOPIC_ASSOC,
+                                 ?P_CORRELATION_DATA_ASSOC,
+                                 ?P_SUBSCRIPTION_ID_ASSOC,
+                                 ?P_TOPIC_ALIAS_ASSOC,
+                                 ?P_USER_PROPERTY_ASSOC}.
+
+-record(mqtt5_puback, {
+          message_id        :: msg_id(),
+          reason_code       :: reason_code(),
+          properties=#{}    :: mqtt5_puback_props()
+         }).
+-type mqtt5_puback()        :: #mqtt5_puback{}.
+-type mqtt5_puback_props()  :: #{?P_REASON_STRING_ASSOC,
+                                 ?P_USER_PROPERTY_ASSOC}.
+
+-record(mqtt5_pubrec, {
+          message_id        :: msg_id(),
+          reason_code       :: reason_code(),
+          properties=#{}    :: mqtt5_pubrec_props()
+         }).
+-type mqtt5_pubrec()        :: #mqtt5_pubrec{}.
+-type mqtt5_pubrec_props()  :: #{?P_REASON_STRING_ASSOC,
+                                 ?P_USER_PROPERTY_ASSOC}.
+
+-record(mqtt5_pubrel, {
+          message_id        :: msg_id(),
+          reason_code       :: reason_code(),
+          properties=#{}    :: mqtt5_pubrel_props()
+         }).
+-type mqtt5_pubrel()        :: #mqtt5_pubrel{}.
+-type mqtt5_pubrel_props()  :: #{?P_REASON_STRING_ASSOC,
+                                 ?P_USER_PROPERTY_ASSOC}.
+-record(mqtt5_pubcomp, {
+          message_id        :: msg_id(),
+          reason_code       :: reason_code(),
+          properties=#{}    :: mqtt5_pubcomp_props()
+         }).
+-type mqtt5_pubcomp()       :: #mqtt5_pubcomp{}.
+-type mqtt5_pubcomp_props() :: #{?P_REASON_STRING_ASSOC,
+                                 ?P_USER_PROPERTY_ASSOC}.
+
+-type no_local() :: flag().
+-type rap() :: flag().
+-type retain_handling() :: send_retain | send_if_new_sub | dont_send.
+
+-record(mqtt5_subscribe_topic, {
+          topic             :: topic(),
+          qos               :: qos(),
+          no_local          :: no_local(),
+          rap               :: rap(),
+          retain_handling   :: retain_handling()
+         }).
+-type mqtt5_subscribe_topic() :: #mqtt5_subscribe_topic{}.
+
+-record(mqtt5_subscribe, {
+          message_id        :: msg_id(),
+          topics=[]         :: [mqtt5_subscribe_topic()],
+          properties=#{}    :: mqtt5_sub_props()
+         }).
+-type mqtt5_subscribe()     :: #mqtt5_subscribe{}.
+-type mqtt5_sub_props()     :: #{?P_SUBSCRIPTION_ID_ASSOC,
+                                 ?P_USER_PROPERTY_ASSOC}.
+
+-record(mqtt5_suback, {
+          message_id        :: msg_id(),
+          reason_codes=[]   :: [?M5_GRANTED_QOS0 |
+                                ?M5_GRANTED_QOS1 |
+                                ?M5_GRANTED_QOS2 |
+                                ?M5_UNSPECIFIED_ERROR |
+                                ?M5_IMPL_SPECIFIC_ERROR |
+                                ?M5_NOT_AUTHORIZED |
+                                ?M5_TOPIC_FILTER_INVALID |
+                                ?M5_PACKET_ID_IN_USE |
+                                ?M5_QUOTA_EXCEEDED |
+                                ?M5_SHARED_SUBS_NOT_SUPPORTED |
+                                ?M5_SUBSCRIPTION_IDS_NOT_SUPPORTED |
+                                ?M5_WILDCARD_SUBS_NOT_SUPPORTED],
+          properties=#{}     :: mqtt5_suback_props()
+         }).
+-type mqtt5_suback()        :: #mqtt5_suback{}.
+-type mqtt5_suback_props( ) :: #{?P_REASON_STRING_ASSOC,
+                                 ?P_USER_PROPERTY_ASSOC}.
+
+-record(mqtt5_unsubscribe, {
+          message_id        :: msg_id(),
+          topics=[]         :: nonempty_list(topic()),
+          properties=#{}    :: mqtt5_unsub_props()
+         }).
+-type mqtt5_unsubscribe()   :: #mqtt5_unsubscribe{}.
+-type mqtt5_unsub_props()   :: #{?P_USER_PROPERTY_ASSOC}.
+
+-record(mqtt5_unsuback, {
+          message_id        :: msg_id(),
+          reason_codes=[]   :: [?M5_SUCCESS |
+                                ?M5_NO_SUBSCRIPTION_EXISTED |
+                                ?M5_UNSPECIFIED_ERROR |
+                                ?M5_IMPL_SPECIFIC_ERROR |
+                                ?M5_NOT_AUTHORIZED |
+                                ?M5_TOPIC_FILTER_INVALID |
+                                ?M5_PACKET_ID_IN_USE |
+                                ?M5_QUOTA_EXCEEDED],
+          properties=#{}     :: mqtt5_unsuback_props()
+         }).
+-type mqtt5_unsuback()      :: #mqtt5_unsuback{}.
+-type mqtt5_unsuback_props( ) :: #{?P_REASON_STRING_ASSOC,
+                                   ?P_USER_PROPERTY_ASSOC}.
+
+-record(mqtt5_pingreq, {}).
+-type mqtt5_pingreq()       :: #mqtt5_pingreq{}.
+
+-record(mqtt5_pingresp, {}).
+-type mqtt5_pingresp()      :: #mqtt5_pingresp{}.
+
+-record(mqtt5_disconnect, {
+          reason_code       :: ?M5_NORMAL_DISCONNECT |
+                               ?M5_DISCONNECT_WITH_WILL_MSG |
+                               ?M5_UNSPECIFIED_ERROR |
+                               ?M5_MALFORMED_PACKET |
+                               ?M5_PROTOCOL_ERROR |
+                               ?M5_IMPL_SPECIFIC_ERROR |
+                               ?M5_NOT_AUTHORIZED |
+                               ?M5_NOT_AUTHORIZED |
+                               ?M5_SERVER_BUSY |
+                               ?M5_SERVER_SHUTTING_DOWN |
+                               ?M5_KEEP_ALIVE_TIMEOUT |
+                               ?M5_SESSION_TAKEN_OVER |
+                               ?M5_TOPIC_FILTER_INVALID |
+                               ?M5_TOPIC_NAME_INVALID |
+                               ?M5_RECEIVE_MAX_EXCEEDED |
+                               ?M5_TOPIC_ALIAS_INVALID |
+                               ?M5_PACKET_TOO_LARGE |
+                               ?M5_MESSAGE_RATE_TOO_HIGH |
+                               ?M5_QUOTA_EXCEEDED |
+                               ?M5_ADMINISTRATIVE_ACTION |
+                               ?M5_PAYLOAD_FORMAT_INVALID |
+                               ?M5_RETAIN_NOT_SUPPORTED |
+                               ?M5_QOS_NOT_SUPPORTED |
+                               ?M5_USE_ANOTHER_SERVER |
+                               ?M5_SERVER_MOVED |
+                               ?M5_SHARED_SUBS_NOT_SUPPORTED |
+                               ?M5_CONNECTION_RATE_EXCEEDED |
+                               ?M5_MAX_CONNECT_TIME |
+                               ?M5_SUBSCRIPTION_IDS_NOT_SUPPORTED |
+                               ?M5_WILDCARD_SUBS_NOT_SUPPORTED,
+          properties=#{}     :: mqtt5_disconnect_props()
+         }).
+-type mqtt5_disconnect()    :: #mqtt5_disconnect{}.
+-type mqtt5_disconnect_props() :: #{?P_SESSION_EXPIRY_INTERVAL_ASSOC,
+                                    ?P_SERVER_REF_ASSOC,
+                                    ?P_REASON_STRING_ASSOC,
+                                    ?P_USER_PROPERTY_ASSOC}.
+
+-record(mqtt5_auth, {
+         reason_code        :: ?M5_SUCCESS |
+                               ?M5_CONTINUE_AUTHENTICATION |
+                               ?M5_REAUTHENTICATE,
+         properties=#{}     :: mqtt5_auth_props()
+         }).
+-type mqtt5_auth()          :: #mqtt5_auth{}.
+-type mqtt5_auth_props()    :: #{?P_AUTHENTICATION_METHOD_ASSOC,
+                                 ?P_AUTHENTICATION_DATA_ASSOC,
+                                 ?P_REASON_STRING_ASSOC,
+                                 ?P_USER_PROPERTY_ASSOC}.
+
+-type mqtt5_frame()         :: mqtt5_connect()
+                             | mqtt5_connack()
+                             | mqtt5_publish()
+                             | mqtt5_puback()
+                             | mqtt5_pubrec()
+                             | mqtt5_pubrel()
+                             | mqtt5_pubcomp()
+                             | mqtt5_subscribe()
+                             | mqtt5_suback()
+                             | mqtt5_unsubscribe()
+                             | mqtt5_unsuback()
+                             | mqtt5_pingreq()
+                             | mqtt5_pingresp()
+                             | mqtt5_disconnect()
+                             | mqtt5_auth().
+
+%% TODO: these are only preliminary types so we had something to use
+%% below. Should probable be replaced with something else.
+-type utf8string() :: binary().
+-type user_property() :: {utf8string(), utf8string()}.
+-type seconds() :: non_neg_integer().
+
+%% MQTT5 property records and types
+-record(p_payload_format_indicator, {
+          value :: unspecified | utf8
+         }).
+-record(p_message_expiry_interval, {value :: seconds()}).
+-record(p_content_type, {value :: utf8string()}).
+-record(p_response_topic, {value :: topic()}).
+-record(p_correlation_data, {value :: binary()}).
+%% As there can be more than one subscription id in an outgoing
+%% publish frame (only one in a subscribe frame) and we represent the
+%% properties as a map we store multiple values in the record.
+-type subscription_id() :: 1..268435455.
+-record(p_subscription_id, {value :: [subscription_id()]}).
+-record(p_session_expiry_interval, {value :: seconds()}).
+-record(p_assigned_client_id, {value :: utf8string()}).
+-record(p_server_keep_alive, {value :: seconds()}).
+-record(p_authentication_method, {value :: utf8string()}).
+-record(p_authentication_data, {value :: binary()}).
+-record(p_request_problem_info, {value :: boolean()}).
+-record(p_will_delay_interval, {value :: seconds()}).
+-record(p_request_response_info, {value :: boolean()}).
+-record(p_response_info, {value :: utf8string()}).
+-record(p_server_ref, {value :: utf8string()}).
+-record(p_reason_string, {value :: utf8string()}).
+-record(p_receive_max, {value :: 1..65535}).
+-record(p_topic_alias_max, {value :: 0..65535}).
+-record(p_topic_alias, {value :: 1..65535}).
+%% Spec: It is a Protocol Error to include Maximum QoS more than once,
+%% or to have a value other than 0 or 1. If the Maximum QoS is absent,
+%% the Client uses a Maximum QoS of 2.
+%%
+%% TODO: Maybe we want to explicity model qos2 as well as that might
+%% be easier to handle in the code - in that case we should extend
+%% this type to include 2.q
+-record(p_max_qos, {value :: 0 | 1}).
+-record(p_retain_available, {value :: boolean()}).
+%% as there can be more than one user property id in a single frame
+%% and we represent the properties as a map we store multiple values
+%% in the record.
+-record(p_user_property, {value :: [user_property()]}).
+-record(p_max_packet_size, {value :: 1..4294967296}).
+-record(p_wildcard_subs_available, {value :: boolean()}).
+-record(p_sub_ids_available, {value :: boolean()}).
+-record(p_shared_subs_available, {value :: boolean()}).
+
+-type reason_code()         :: ?M5_SUCCESS
+                             | ?M5_GRANTED_QOS0
+                             | ?M5_GRANTED_QOS1
+                             | ?M5_GRANTED_QOS2
+                             | ?M5_DISCONNECT_WITH_WILL_MSG
+                             | ?M5_NO_MATCHING_SUBSCRIBERS
+                             | ?M5_NO_SUBSCRIPTION_EXISTED
+                             | ?M5_CONTINUE_AUTHENTICATION
+                             | ?M5_REAUTHENTICATE
+                             | ?M5_UNSPECIFIED_ERROR
+                             | ?M5_MALFORMED_PACKET
+                             | ?M5_PROTOCOL_ERROR
+                             | ?M5_IMPL_SPECIFIC_ERROR
+                             | ?M5_UNSUPPORTED_PROTOCOL_VERSION
+                             | ?M5_CLIENT_IDENTIFIER_NOT_VALID
+                             | ?M5_BAD_USERNAME_OR_PASSWORD
+                             | ?M5_NOT_AUTHORIZED
+                             | ?M5_SERVER_UNAVAILABLE
+                             | ?M5_SERVER_BUSY
+                             | ?M5_BANNED
+                             | ?M5_SERVER_SHUTTING_DOWN
+                             | ?M5_BAD_AUTHENTICATION_METHOD
+                             | ?M5_KEEP_ALIVE_TIMEOUT
+                             | ?M5_SESSION_TAKEN_OVER
+                             | ?M5_TOPIC_FILTER_INVALID
+                             | ?M5_TOPIC_NAME_INVALID
+                             | ?M5_PACKET_ID_IN_USE
+                             | ?M5_PACKET_ID_NOT_FOUND
+                             | ?M5_RECEIVE_MAX_EXCEEDED
+                             | ?M5_TOPIC_ALIAS_INVALID
+                             | ?M5_PACKET_TOO_LARGE
+                             | ?M5_MESSAGE_RATE_TOO_HIGH
+                             | ?M5_QUOTA_EXCEEDED
+                             | ?M5_ADMINISTRATIVE_ACTION
+                             | ?M5_PAYLOAD_FORMAT_INVALID
+                             | ?M5_RETAIN_NOT_SUPPORTED
+                             | ?M5_QOS_NOT_SUPPORTED
+                             | ?M5_USE_ANOTHER_SERVER
+                             | ?M5_SERVER_MOVED
+                             | ?M5_SHARED_SUBS_NOT_SUPPORTED
+                             | ?M5_CONNECTION_RATE_EXCEEDED
+                             | ?M5_MAX_CONNECT_TIME
+                             | ?M5_SUBSCRIPTION_IDS_NOT_SUPPORTED
+                             | ?M5_WILDCARD_SUBS_NOT_SUPPORTED.


### PR DESCRIPTION
This is *not* guaranteed to work atm.
It's an attempt to switch away from the old original MQTT client behaviour, and make the worker more self-contained by extracting some type files and some additional modules (topic parser) from VerneMQ.

While potentially solving some issues, this may or may not introduce some other subtle issues.