### PR TITLE
Fix git URLs Used During Cloning

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,8 +16,8 @@
 
 {deps, [
         {lager, ".*",
-            {git, "git://github.com/basho/lager.git", {tag, "2.2.3"}}},
-            {vernemq_dev, ".*", {git, "git://github.com/vernemq/vernemq_dev.git", {tag, "1.1.0"}}}
+            {git, "https://github.com/basho/lager.git", {tag, "2.2.3"}}},
+            {vernemq_dev, ".*", {git, "https://github.com/vernemq/vernemq_dev.git", {tag, "1.1.0"}}}
         ]
         }.
 


### PR DESCRIPTION
I think the correct URLS supported by git clone commands are
```bash
git@github.com:basho/lager.git
```
or

```bash
https://github.com/basho/lager.git
```

I get the following errors

```bash
Pulling lager from {git,"git://github.com/basho/lager.git",{tag,"2.2.3"}}
fatal: unable to connect to github.com:
github.com[0: 20.87.225.212]: errno=Connection timed out
github.com[1: 64:ff9b::1457:e1d4]: errno=Cannot assign requested address
```

![image](https://github.com/vernemq/vmq_mzbench/assets/28790446/6a9cff54-3505-40fa-b4d4-8925890855c6)
